### PR TITLE
Fix link for write a tutorial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [LICENSE](LICENSE.md).
 [tutorials]: https://cloud.google.com/community/tutorials/
 [contribute]: https://cloud.google.com/community/contribute/
 [request]: https://github.com/GoogleCloudPlatform/community/issues/new?title=Tutorial%20Request:%20<title>&body=Description%0A%0ATechnical%20Level%0Abeginner%20%7C%20intermediate%20%7C%20advanced%0A%0ALength%0Ashort%20(<%20250%20words)%20%7C%20medium%20(250-500%20words)%20%7C%20long%20(1000%20words+)%0A
-[write]: https://github.com/GoogleCloudPlatform/community/write
+[write]: https://cloud.google.com/community/write
 [cca]: https://creativecommons.org/licenses/by/4.0/
 [apache]: http://www.apache.org/licenses/LICENSE-2.0
 [authors]: https://github.com/GoogleCloudPlatform/community/blob/master/AUTHORS


### PR DESCRIPTION
I think this was supposed to point to cloud site not the GitHub repo (404).
