### PR TITLE
Fix path for postgres archive command 

### DIFF
--- a/tutorials/setting-up-postgres-hot-standby.md
+++ b/tutorials/setting-up-postgres-hot-standby.md
@@ -235,7 +235,7 @@ WAL level:
 1. Change the value for the archive command. This setting tells Postgres to
 write the archive files to the directory that you created in a previous step:
 
-        archive_command = 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+        archive_command = 'test ! -f mnt/server/archivedir/%f && cp %p mnt/server/archivedir/%f'
 
 1. In the **REPLICATION** section, in the **Sending Server(s)** section,
 change the value for the maximum number of WAL sender processes:


### PR DESCRIPTION
Because we create archive dir under  postgres working dir 
`$ mkdir -p ../../var/lib/postgresql/main/mnt/server/archivedir` -> `/var/lib/postgresql/main/mnt/server/archivedir` 

`archive_command` will fail to write in `/mnt/server/archivedir` dir. 
