### PR TITLE
Update Kitura dependency to 1.7

### DIFF
--- a/tutorials/run-swift-kitura-on-google-cloud/Package.swift
+++ b/tutorials/run-swift-kitura-on-google-cloud/Package.swift
@@ -6,6 +6,6 @@ let package = Package(
         Target(name: "KituraGAE", dependencies: [])
     ],
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 3),
+        .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 7),
         ]
 )


### PR DESCRIPTION
The latest docker image is incompatible with 1.3, so the tutorial fails.