### PR TITLE
Update Twilio SMS Tutorial to Twilio Node.js 3.x 

### DIFF
--- a/tutorials/cloud-functions-twilio-sms/index.js
+++ b/tutorials/cloud-functions-twilio-sms/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const MessagingResponse = require('twilio').twiml.MessagingResponse;
 const twilio = require('twilio');
 const config = require('./config.json');
+
+const MessagingResponse = twilio.twiml.MessagingResponse;
 
 const projectId = process.env.GCLOUD_PROJECT;
 const region = 'us-central1';

--- a/tutorials/cloud-functions-twilio-sms/index.js
+++ b/tutorials/cloud-functions-twilio-sms/index.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const MessagingResponse = require('twilio').twiml.MessagingResponse;
 const twilio = require('twilio');
 const config = require('./config.json');
+
+const projectId = process.env.GCLOUD_PROJECT;
+const region = 'us-central1';
 
 exports.reply = (req, res) => {
   let isValid = true;
@@ -9,7 +13,9 @@ exports.reply = (req, res) => {
   // Only validate that requests came from Twilio when the function has been
   // deployed to production.
   if (process.env.NODE_ENV === 'production') {
-    isValid = twilio.validateExpressRequest(req, config.TWILIO_AUTH_TOKEN);
+    isValid = twilio.validateExpressRequest(req, config.TWILIO_AUTH_TOKEN, {
+      url: `https://${region}-${projectId}.cloudfunctions.net/reply`
+    });
   }
 
   // Halt early if the request was not sent from Twilio
@@ -23,7 +29,7 @@ exports.reply = (req, res) => {
   }
 
   // Prepare a response to the SMS message
-  const response = new twilio.TwimlResponse();
+  const response = new MessagingResponse();
 
   // Add text to the response
   response.message('Hello from Google Cloud Functions!');

--- a/tutorials/cloud-functions-twilio-sms/index.md
+++ b/tutorials/cloud-functions-twilio-sms/index.md
@@ -95,13 +95,20 @@ Create a file named `index.js` with the following contents:
 const twilio = require('twilio');
 const config = require('./config.json');
 
+const MessagingResponse = twilio.twiml.MessagingResponse;
+
+const projectId = process.env.GCLOUD_PROJECT;
+const region = 'us-central1';
+
 exports.reply = (req, res) => {
   let isValid = true;
 
   // Only validate that requests came from Twilio when the function has been
   // deployed to production.
   if (process.env.NODE_ENV === 'production') {
-    isValid = twilio.validateExpressRequest(req, config.TWILIO_AUTH_TOKEN);
+    isValid = twilio.validateExpressRequest(req, config.TWILIO_AUTH_TOKEN, {
+      url: `https://${region}-${projectId}.cloudfunctions.net/reply`
+    });
   }
 
   // Halt early if the request was not sent from Twilio
@@ -115,7 +122,7 @@ exports.reply = (req, res) => {
   }
 
   // Prepare a response to the SMS message
-  const response = new twilio.TwimlResponse();
+  const response = new MessagingResponse();
 
   // Add text to the response
   response.message('Hello from Google Cloud Functions!');

--- a/tutorials/cloud-functions-twilio-sms/package.json
+++ b/tutorials/cloud-functions-twilio-sms/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {
-    "twilio": "2.11.1"
+    "twilio": "3.0.0"
   },
   "engines": {
     "node": ">=6.9.0"


### PR DESCRIPTION
Twilio updated the Node.js library to use slightly different syntax for a SMS response. See [here](https://twilio.github.io/twilio-node/3.0.0/MessagingResponse.html) for more detail. This PR updates the tutorial syntax to the latest version of their Node.js lib.

Also updated request validation to match voice response [tutorial](https://github.com/GoogleCloudPlatform/community/blob/master/tutorials/cloud-functions-twilio-voice-record/index.js#L127-L130). Happy to update that tutorial as well if needed. 