### PR TITLE
Update index.md to force default project on gsutil

### DIFF
--- a/tutorials/managing-gcp-projects-with-terraform/index.md
+++ b/tutorials/managing-gcp-projects-with-terraform/index.md
@@ -124,7 +124,7 @@ gcloud beta organizations add-iam-policy-binding ${TF_VAR_org_id} \
 Create the remote backend bucket in Cloud Storage and the `backend.tf` file for storage of the `terraform.tfstate` file:
 
 ```sh
-gsutil mb gs://${TF_ADMIN}
+gsutil mb -p ${TF_ADMIN} gs://${TF_ADMIN}
  
 cat > backend.tf <<EOF
 terraform {  


### PR DESCRIPTION
gsutil within cloud shell does not identify a project from core.project (set by --set-as-default. 
Options are:
a) pass project with -p
b) run gcloud config set project ${TF_ADMIN}

I picked a.