### PR TITLE
Update link to Cloud SQL to make the benefit more clear

### DIFF
--- a/tutorials/setting-up-postgres.md
+++ b/tutorials/setting-up-postgres.md
@@ -9,7 +9,10 @@ This tutorial shows how to set up [PostgreSQL](https://www.postgresql.org) on
 Google Cloud Platform in just a few minutes. Follow this tutorial to configure
 PostgreSQL on an Ubuntu virtual machine instance on Compute Engine.
 
-You can also use Postgres as a service through [Google Cloud SQL](https://cloud.google.com/sql/docs/postgres/). Or you can use [Cloud Launcher](https://cloud.google.com/launcher/?q=postgres)
+If you don't want to install and manage your own PostgreSQL database,
+[Google Cloud SQL](https://cloud.google.com/sql/docs/postgres/) provides managed PostgreSQL.
+
+You can also use [Cloud Launcher](https://cloud.google.com/launcher/?q=postgres)
 to set up PostgreSQL on Compute Engine with just a few clicks.
 
 


### PR DESCRIPTION
Some metrics from this page suggested that success rate was low, and that they were in fact searching for Cloud SQL for PostgreSQL. However, few if any actually clicked the link in the intro. I tried to make it stand out a bit more, and make it more obvious that it would be a way to get around having to install and maintain the database.