### PR TITLE
Uploading ssl files to nginx with scp

### DIFF
--- a/tutorials/https-load-balancing-nginx/index.md
+++ b/tutorials/https-load-balancing-nginx/index.md
@@ -260,25 +260,25 @@ To create your NGINX instance:
 
 1.  Create a folder for your ssl certificates on your instance:
 
-        mkdir ~/ssl_certs
+        mkdir ~/ssl_certs
         
 1.  Run the `exit` command to exit your SSH session.
 
-After you've exited your session, use `gcloud compute` to copy your private key,
-SSL/TLS certificate, and (if applicable) certificate authority PEM file to the
-load balancer instance:
+    After you've exited your session, use `gcloud compute` to copy your private key,
+    SSL/TLS certificate, and (if applicable) certificate authority PEM file to the
+    load balancer instance:
 
-    gcloud compute scp /local/path/to/ssl-certs/* \
-      nginx-lb:~/ssl-certs --zone us-central1-f
+        gcloud compute scp /local/path/to/ssl-certs/* \
+        nginx-lb:~/ssl-certs --zone us-central1-f
 
-Since you do not have write access for */etc/nginx*, you will have to log on to the load balancer instance and move the files to the correct folder.
+    Since you do not have write access for */etc/nginx*, you will have to log on to the load balancer instance and move the files to the correct folder.
 
 1.  Reconnect to your **nginx-lb**:
 
-        gcloud compute ssh nginx-lb
+        gcloud compute ssh nginx-lb
         
-1.  Move your folder for ssl ceritifcate to nginx:
-        
+1.  Move your folder for ssl certificate to NGINX:
+
         sudo mv ~/ssl-certs /etc/nginx/
 
 ### Create your virtual host

--- a/tutorials/https-load-balancing-nginx/index.md
+++ b/tutorials/https-load-balancing-nginx/index.md
@@ -258,15 +258,28 @@ To create your NGINX instance:
 
         sudo apt-get install -y nginx
 
+1.  Create a folder for your ssl certificates on your instance:
 
+        mkdir ~/ssl_certs
+        
 1.  Run the `exit` command to exit your SSH session.
 
 After you've exited your session, use `gcloud compute` to copy your private key,
 SSL/TLS certificate, and (if applicable) certificate authority PEM file to the
 load balancer instance:
 
-    gcloud compute copy-files /local/path/to/ssl-certs \
-      root@nginx-lb:/etc/nginx --zone us-central1-f
+    gcloud compute scp /local/path/to/ssl-certs/* \
+      nginx-lb:~/ssl-certs --zone us-central1-f
+
+Since you do not have write access for */etc/nginx*, you will have to log on to the load balancer instance and move the files to the correct folder.
+
+1.  Reconnect to your **nginx-lb**:
+
+        gcloud compute ssh nginx-lb
+        
+1.  Move your folder for ssl ceritifcate to nginx:
+        
+        sudo mv ~/ssl-certs /etc/nginx/
 
 ### Create your virtual host
 


### PR DESCRIPTION
Replaced deprecated *gcloud compute copy-files* with *gcloud compute scp* for adding ssl files to nginx. Adding separate tasks for moving files to correct folder due to missing write access and scp not supporting root login on gcloud instances.
