### PR TITLE
awk command is a bit obscure for a tutorial

### DIFF
--- a/tutorials/managing-gcp-projects-with-terraform/index.md
+++ b/tutorials/managing-gcp-projects-with-terraform/index.md
@@ -261,7 +261,8 @@ terraform apply
 SSH into the instance created:
 
 ```sh
-eval $(terraform output  | awk -F' = ' '// {print "export " $1"="$2}')
+export instance_id=$(terraform output instance_id)
+export project_id=$(terraform output project_id)
 
 gcloud compute ssh ${instance_id} --project ${project_id}
 ```


### PR DESCRIPTION
Someone who doesn't know the unix shell command well will find the following command to be hard to follow:

`eval $(terraform output  | awk -F' = ' '// {print "export " $1"="$2}')`

Replaced it with more 'readable' commands.