### PR TITLE
Add GCS versioning to terraform on GCP guide

### DIFF
--- a/tutorials/managing-gcp-projects-with-terraform/index.md
+++ b/tutorials/managing-gcp-projects-with-terraform/index.md
@@ -139,6 +139,12 @@ terraform {
 EOF
 ```
 
+Enable versioning for said remote bucket:
+
+```sh
+gsutil versioning set on gs://${TF_ADMIN}
+```
+
 Configure your environment for the Google Cloud Terraform provider:
 
 ```sh


### PR DESCRIPTION
My terraform state file was just overwritten by a bad `terraform refresh`, and because versioning was not enabled, I lost thus the whole state. This change will hopefully prevent this horrible mistake in the future.