### PR TITLE
Update Elixir-GAE tutorial to include distillery releases

### DIFF
--- a/tutorials/elixir-phoenix-on-google-app-engine.md
+++ b/tutorials/elixir-phoenix-on-google-app-engine.md
@@ -87,7 +87,7 @@ Erlang) applications for deployment. You will configure the
 for your app.
 
 **Note:** If you already have Distillery set up for your application, you can
-skip this section. But make sure `include_erts: true` is set in your `:prod`
+skip this section, but make sure `include_erts: true` is set in your `:prod`
 release configuration. The Elixir Runtime assumes ERTS is included in releases.
 
 ### Set up Distillery


### PR DESCRIPTION
The tutorial as originally written, covered deployments without using OTP releases. This was because the Elixir Runtime did not support releases at the time. However, release support has since been added to the runtime. And because use of OTP releases is strongly considered a deployment best practice in the Erlang and Elixir communities, we thought it best to update the tutorial to reference them, even if it lengthens the tutorial a bit. (Note that the corresponding tutorials for [GKE](https://cloud.google.com/community/tutorials/elixir-phoenix-on-kubernetes-google-container-engine) and [GCE](https://cloud.google.com/community/tutorials/elixir-phoenix-on-google-compute-engine) already use OTP releases; indeed the new section on Distillery is largely copy-pasted from the GKE tutorial. Note also that the original version of this tutorial without releases does continue to work.)

Recommend @chingor13 or @bshaffer for content review.