### PR TITLE
Clarify Docker usage in Elixir-GCE tutorial

### DIFF
--- a/tutorials/elixir-phoenix-on-google-compute-engine/index.md
+++ b/tutorials/elixir-phoenix-on-google-compute-engine/index.md
@@ -179,7 +179,10 @@ Now you can create a release to test out your configuration.
 Building a release for deploying to the cloud is a bit more complicated
 because your build needs to take place in the same operating system and
 architecture as your deployment environment. In this section, you will use
-Docker to build a deployable release, and upload it to Google Cloud Storage.
+Docker to cross-compile a release that can run on Compute Engine VMs. (Docker
+will be used only for cross-compilation. Your release will run directly on the
+VM, not in a Docker container.) You'll then upload your built release to a
+Cloud Storage bucket.
 
 ### Prepare a Cloud Storage bucket
 

--- a/tutorials/elixir-phoenix-on-google-compute-engine/index.md
+++ b/tutorials/elixir-phoenix-on-google-compute-engine/index.md
@@ -179,10 +179,9 @@ Now you can create a release to test out your configuration.
 Building a release for deploying to the cloud is a bit more complicated
 because your build needs to take place in the same operating system and
 architecture as your deployment environment. In this section, you will use
-Docker to cross-compile a release that can run on Compute Engine VMs. (Docker
-will be used only for cross-compilation. Your release will run directly on the
-VM, not in a Docker container.) You'll then upload your built release to a
-Cloud Storage bucket.
+Docker to cross-compile a release (which will eventually run directly on a
+Compute Engine VM, not in a Docker container). Then, you will upload your
+release to a Cloud Storage bucket.
 
 ### Prepare a Cloud Storage bucket
 


### PR DESCRIPTION
I received [feedback](https://github.com/GoogleCloudPlatform/elixir-runtime/issues/6#issuecomment-348820048) on this tutorial that it wasn't clear how Docker was being used. A reader thought that we were deploying Docker containers themselves to GCE (which is not considered good practice for Elixir apps) whereas we are actually using Docker only to do cross-compilation. This clarifies the language.