### PR TITLE
New tutorial: serve machine learning models with App Engine and Cloud Endpoints

### DIFF
--- a/tutorials/appengine-serve-machine-learning-model/index.md
+++ b/tutorials/appengine-serve-machine-learning-model/index.md
@@ -1,5 +1,5 @@
 ---
-title: Falcon API on App Engine Standard Environment
+title: Serve Machine Learning Model on App Engine Flex
 description: Learn how to serve a trained machine learning model with Google App Engine flex environment.
 author: dizcology
 tags: App Engine, Cloud Endpoints, Machine Learning

--- a/tutorials/appengine-serve-machine-learning-model/index.md
+++ b/tutorials/appengine-serve-machine-learning-model/index.md
@@ -1,0 +1,65 @@
+---
+title: Falcon API on App Engine Standard Environment
+description: Learn how to serve a trained machine learning model with Google App Engine flex environment.
+author: dizcology
+tags: App Engine, Cloud Endpoints, Machine Learning
+date_published: 
+---
+This tutorial takes a deeper look at the sample app [Model serve][modelserve].  It helps you build your own service serving a trained machine learning model for online prediction.
+
+## Objectives
+
+1. Deploy a service with [Google Cloud Endpoints][endpoints].
+1. Deploy a Python app on [Google App Engine][appengine] which loads a trained machine learning model.
+1. Send requests to the service and get responses.
+
+## Before you begin
+
+Follow the links in the [Requirements section][requirements] to install Google Cloud Platform SDK and enable the APIs for App Engine, Cloud Endpoints, and Google Cloud Storage.
+
+## Overview
+
+So you trained a machine learning model.  Now what?
+
+If the model’s performance is good enough, consider deploying it as a service to a production system where one or more clients can use it.  Some possible scenarios include:
+
+- The model might need to process requests in real time when the users are interacting with your web application while at the same time batch process interaction logs you have stored previously in a database.
+
+- The model's output might be used by multiple other machine learning models in your application.
+
+App Engine offers rolling update, networking, and auto scaling.
+
+Cloud Endpoints helps you manage permission and quota of the service's consumers.
+
+You can follow the [steps of the sample app][steps] to deploy a service.  Below we will look at some key pieces of the code to understand how it works.
+
+## Deployment process
+
+All the codes and configuration files are available [here][modelserve].
+
+1. Copy a trained machine learning model to Cloud Storage.
+
+1. Update [`modelserve.yaml`][modelserve.yaml] and deploy the service.
+
+1. Update [`app.yaml`][app.yaml] and deploy the app.
+
+1. Test the service.
+
+## A closer look
+
+### [`modelserve.yaml`][modelserve.yaml]
+
+### [`app.yaml`][app.yaml]
+
+### [`main.py`][main.py]
+
+
+[modelserve]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve
+[requirements]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve#requirements
+[appengine]: https://cloud.google.com/appengine/
+[endpoints]: https://cloud.google.com/endpoints/
+[steps]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve#steps
+[modelserve.yaml]: https://github.com/GoogleCloudPlatform/ml-on-gcp/blob/master/sklearn/gae_serve/modelserve.yaml
+[app.yaml]: https://github.com/GoogleCloudPlatform/ml-on-gcp/blob/master/sklearn/gae_serve/app.yaml
+[main.py]: https://github.com/GoogleCloudPlatform/ml-on-gcp/blob/master/sklearn/gae_serve/main.py
+

--- a/tutorials/appengine-serve-machine-learning-model/index.md
+++ b/tutorials/appengine-serve-machine-learning-model/index.md
@@ -139,7 +139,7 @@ The `modelserve.yaml` configuration file defines the service according to the [O
 
   This configurations declares a metric `modelserve-predict` and sets its limit to 1000 units per minutes per project.
 
-  To specify requests to which paths will be counted towards this metric, we add the following in the `paths` field:
+  To specify the paths to which requests will be counted towards this metric, we add the following in the `paths` field:
 
   ```yaml
   paths:

--- a/tutorials/appengine-serve-machine-learning-model/index.md
+++ b/tutorials/appengine-serve-machine-learning-model/index.md
@@ -3,7 +3,7 @@ title: Serve Machine Learning Model on App Engine Flexible Environment
 description: Learn how to serve a trained machine learning model with App Engine flexible environment.
 author: dizcology
 tags: App Engine, Cloud Endpoints, Machine Learning
-date_published: 
+date_published: 2017-12-18
 ---
 This tutorial takes a deeper look at the sample app [Model serve][modelserve].  It helps you build your own service serving a trained machine learning model for online prediction.
 

--- a/tutorials/appengine-serve-machine-learning-model/index.md
+++ b/tutorials/appengine-serve-machine-learning-model/index.md
@@ -23,9 +23,9 @@ So you trained a machine learning model.  Now what?
 
 If the model’s performance is good enough, consider deploying it as a service to a production system where one or more clients can use it.  Some possible scenarios include:
 
-- The model might need to process requests in real time when the users are interacting with your web application while at the same time batch process interaction logs you have stored previously in a database.
+- The model needs to process requests in real time when the users are interacting with your web application while at the same time batch process interaction logs you have stored previously in a database.
 
-- The model's output might be used by multiple other machine learning models in your application.
+- The model's output is used by multiple other machine learning models in your application.
 
 App Engine offers rolling update, networking, and auto scaling.
 
@@ -33,21 +33,39 @@ Cloud Endpoints helps you manage permission and quota of the service's consumers
 
 You can follow the [steps of the sample app][steps] to deploy a service.  Below we will look at some key pieces of the code to understand how it works.
 
-## Deployment process
-
-All the codes and configuration files are available [here][modelserve].
-
-1. Copy a trained machine learning model to Cloud Storage.
-
-1. Update [`modelserve.yaml`][modelserve.yaml] and deploy the service.
-
-1. Update [`app.yaml`][app.yaml] and deploy the app.
-
-1. Test the service.
-
 ## A closer look
 
 ### [`modelserve.yaml`][modelserve.yaml]
+
+The `modelserve.yaml` configuration file defines the service according to the [OpenAPI specification][openapi].
+
+- Specify the path, method, and input/output types under the `paths` field:
+
+    ```yaml
+    paths:
+      "/predict":
+        post:
+          description: "Get prediction given X."
+          operationId: "predict"
+          consumes:
+          - "application/json"
+          produces:
+          - "application/json"
+    ```
+
+- Enforce authentication with API key by adding the `security` and `securityDefinitions` fields:
+
+    ```yaml
+    security:
+      - api_key: []
+    securityDefinitions:
+      api_key:
+        type: "apiKey"
+        name: "key"
+        in: "query"
+    ```
+
+    With this
 
 ### [`app.yaml`][app.yaml]
 
@@ -56,10 +74,14 @@ All the codes and configuration files are available [here][modelserve].
 
 [modelserve]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve
 [requirements]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve#requirements
-[appengine]: https://cloud.google.com/appengine/
-[endpoints]: https://cloud.google.com/endpoints/
 [steps]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve#steps
 [modelserve.yaml]: https://github.com/GoogleCloudPlatform/ml-on-gcp/blob/master/sklearn/gae_serve/modelserve.yaml
 [app.yaml]: https://github.com/GoogleCloudPlatform/ml-on-gcp/blob/master/sklearn/gae_serve/app.yaml
 [main.py]: https://github.com/GoogleCloudPlatform/ml-on-gcp/blob/master/sklearn/gae_serve/main.py
+[lr.pkl]: https://github.com/GoogleCloudPlatform/ml-on-gcp/blob/master/sklearn/gae_serve/lr.pkl
+
+[appengine]: https://cloud.google.com/appengine/
+[endpoints]: https://cloud.google.com/endpoints/
+
+[openapi]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
 

--- a/tutorials/appengine-serve-machine-learning-model/index.md
+++ b/tutorials/appengine-serve-machine-learning-model/index.md
@@ -5,39 +5,52 @@ author: dizcology
 tags: App Engine, Cloud Endpoints, Machine Learning
 date_published: 2017-12-18
 ---
-This tutorial takes a deeper look at the sample app [Model serve][modelserve].  It helps you build your own service serving a trained machine learning model for online prediction.
+This tutorial takes a deeper look at the sample app [Model serve][modelserve].
+It helps you build your own service serving a trained machine learning model for
+online prediction.
 
 ## Objectives
 
-1. Deploy a service with [Google Cloud Endpoints][endpoints].
-1. Deploy a Python app on [Google App Engine][appengine] which loads a trained machine learning model.
-1. Send requests to the service and get responses.
+1.  Deploy a service with [Google Cloud Endpoints][endpoints].
+1.  Deploy a Python app on [Google App Engine][appengine] which loads a trained
+    machine learning model.
+1.  Send requests to the service and get responses.
 
 ## Before you begin
 
-Follow the links in the [Requirements section][requirements] to install Google Cloud Platform SDK and enable the APIs for App Engine, Cloud Endpoints, and Cloud Storage.
+Follow the links in the [Requirements section][requirements] to install Google
+Cloud Platform SDK and enable the APIs for App Engine, Cloud Endpoints, and
+Cloud Storage.
 
 ## Overview
 
-So you trained a machine learning model.  Now what?
+So you trained a machine learning model. Now what?
 
-If the model’s performance is good enough, consider deploying it as a service to a production system where one or more clients can use it.  Some possible scenarios include:
+If the model's performance is good enough, consider deploying it as a service to
+a production system where one or more clients can use it. Some possible
+scenarios include:
 
-- The model needs to simultaneously process user requests from your web application in real time, and batch process interaction logs you have previously stored in a database.
-
-- The model's output is used by multiple other machine learning models in your application.
+- The model needs to simultaneously process user requests from your web
+  application in real time, and batch process interaction logs you have
+  previously stored in a database.
+- The model's output is used by multiple other machine learning models in your
+  application.
 
 [App Engine][appengine] offers rolling updates, networking, and auto scaling.
 
-[Cloud Endpoints][endpoints] helps you monitor the service's consumers, as well as manage their permissions and quotas.
+[Cloud Endpoints][endpoints] helps you monitor the service's consumers, as well
+as manage their permissions and quotas.
 
-You can follow the [steps of the sample app][steps] to deploy a service.  Below we will look at some key pieces of the code to understand how it works.
+You can follow the [steps of the sample app][steps] to deploy a service. Below
+we will look at some key pieces of the code to understand how it works.
 
 ## A closer look
 
 ### [`main.py`][main.py]
 
-Our app expects `POST` requests to the path `/predict`.  It will look for the value of `'X'` in the JSON data, send it to the trained model, and return the result as the value of `'y'`:
+Our app expects `POST` requests to the path `/predict`.  It will look for the
+value of `'X'` in the JSON data, send it to the trained model, and return the
+result as the value of `'y'`:
 
 ```python
 @app.route('/predict', methods=['POST'])
@@ -47,7 +60,9 @@ def predict():
     return json.dumps({'y': y}), 200
 ```
 
-Here `MODEL` is a global variable for the trained machine learning model we are serving.  To make sure the model is loaded, we use the `before_first_request` decorator, which will be triggered by App Engine's health check requests:
+Here `MODEL` is a global variable for the trained machine learning model we are
+serving.  To make sure the model is loaded, we use the `before_first_request`
+decorator, which will be triggered by App Engine's health check requests:
 
 ```python
 MODEL_BUCKET = os.environ['MODEL_BUCKET']
@@ -65,12 +80,16 @@ def _load_model():
     MODEL = pickle.loads(s)
 ```
 
-We store the model as a pickled file on [Cloud Storage][storage].  To make sure the App Engine service knows where to find the model, we pass in the model's bucket and file name as environment variables.  This is done in the `app.yaml` configuration file.
+We store the model as a pickled file on [Cloud Storage][storage]. To make sure
+the App Engine service knows where to find the model, we pass in the model's
+bucket and file name as environment variables.  This is done in the `app.yaml`
+configuration file.
 
 
 ### [`app.yaml`][app.yaml]
 
-The `app.yaml` configuration file defines the App Engine service.  We define environment variables pointing to the trained model:
+The `app.yaml` configuration file defines the App Engine service. We define
+environment variables pointing to the trained model:
 
 ```yaml
 env_variables:
@@ -79,9 +98,11 @@ env_variables:
     MODEL_FILENAME: lr.pkl
 ```
 
-You should replace `BUCKET_NAME` with a bucket owned by your project.  `lr.pkl` is a simple linear regression model included in the sample app.
+You should replace `BUCKET_NAME` with a bucket owned by your project. `lr.pkl`
+is a simple linear regression model included in the sample app.
 
-To use Cloud Endpoints to manage the service, we need to specify a `config_id` under the `endpoints_api_service` field:
+To use Cloud Endpoints to manage the service, we need to specify a `config_id`
+under the `endpoints_api_service` field:
 
 ```yaml
 endpoints_api_service:
@@ -89,74 +110,83 @@ endpoints_api_service:
   config_id: CONFIG_ID
 ```
 
-The `CONFIG_ID` is the configuration ID of a Cloud Endpoints service deployment.  To find existing deployments and their configuration IDs, go to the [Cloud Endpoints console][endpoints], click on the service's title, then click on the "Deployment history" tab.
+The `CONFIG_ID` is the configuration ID of a Cloud Endpoints service deployment.
+To find existing deployments and their configuration IDs, go to the
+[Cloud Endpoints console][endpoints], click on the service's title, then click
+on the "Deployment history" tab.
 
-To deploy a service to Cloud Endpoints, we configure it with the `modelserve.yaml` file.
+To deploy a service to Cloud Endpoints, we configure it with the
+`modelserve.yaml` file.
 
 ### [`modelserve.yaml`][modelserve.yaml]
 
-The `modelserve.yaml` configuration file defines the service according to the [OpenAPI specification][openapi].  We highlight only some of the key settings below.
+The `modelserve.yaml` configuration file defines the service according to the
+[OpenAPI specification][openapi]. We highlight only some of the key settings
+below.
 
 - Specify the host:
 
-  ```yaml
-  host: "modelserve-dot-PROJECT_ID.appspot.com"
-  ```
+      host: "modelserve-dot-PROJECT_ID.appspot.com"
 
-  This host means we will handle the requests with an App Engine service called `modelserve`.
+  This host means we will handle the requests with an App Engine service called
+  `modelserve`.
 
-- Enforce authentication with an API key by adding the `security` and `securityDefinitions` fields:
+- Enforce authentication with an API key by adding the `security` and
+  `securityDefinitions` fields:
 
-    ```yaml
-    security:
-      - api_key: []
-    securityDefinitions:
-      api_key:
-        type: "apiKey"
-        name: "key"
-        in: "query"
-    ```
+      security:
+        - api_key: []
+      securityDefinitions:
+        api_key:
+          type: "apiKey"
+          name: "key"
+          in: "query"
 
-    This is optional, but allows you to grant service consumer permissions on the [Cloud Endpoints console][endpoints].  The API key must be associated with a Google Cloud Platform project.  You can create API keys on the [credentials][credentials] page.
+  This is optional, but allows you to grant service consumer permissions on the
+  [Cloud Endpoints console][endpoints]. The API key must be associated with a
+  Google Cloud Platform project. You can create API keys on the
+  [credentials][credentials] page.
 
-- Additionally, you can configure quota for each consumer at the project level.  First we specify a service level metric in order to track the number of requests:
+- Additionally, you can configure quota for each consumer at the project level.
+  First we specify a service level metric in order to track the number of
+  requests:
 
-  ```yaml
-  x-google-management:
-    metrics:
-      - name: "modelserve-predict"
-        displayName: "modelserve predict"
-        valueType: INT64
-        metricKind: DELTA
-    quota:
-      limits:
-        - name: "modelserve-predict-limit"
-          metric: "modelserve-predict"
-          unit: "1/min/{project}"
-          values:
-            STANDARD: 1000
-  ```
+      x-google-management:
+        metrics:
+          - name: "modelserve-predict"
+            displayName: "modelserve predict"
+            valueType: INT64
+            metricKind: DELTA
+        quota:
+          limits:
+            - name: "modelserve-predict-limit"
+              metric: "modelserve-predict"
+              unit: "1/min/{project}"
+              values:
+                STANDARD: 1000
 
-  This configurations declares a metric `modelserve-predict` and sets its limit to 1000 units per minute per project.
+  This configurations declares a metric `modelserve-predict` and sets its limit
+  to 1000 units per minute per project.
 
-  Only requests to specified paths are counted towards this metric. Specify these paths by adding the following in the `paths` field:
+  Only requests to specified paths are counted towards this metric. Specify
+  these paths by adding the following in the `paths` field:
 
-  ```yaml
-  paths:
-    "/predict":
-      post:
-        ...
-        x-google-quota:
-          metricCosts:
-            modelserve-predict: 1
-  ```
+      paths:
+        "/predict":
+          post:
+            ...
+            x-google-quota:
+              metricCosts:
+                modelserve-predict: 1
 
-  Each time a `POST` request is sent to `modelserve-dot-PROJECT_ID.appspot.com/predict`, the metric `modelserve-predict` increments by 1, and each project is limited to 1000 calls per minute with the configuration above.
+  Each time a `POST` request is sent to
+  `modelserve-dot-PROJECT_ID.appspot.com/predict`, the metric
+  `modelserve-predict` increments by 1, and each project is limited to 1000
+  calls per minute with the configuration above.
 
-  You can manage quotes for individual projects on the [Cloud Endpoints console][endpoints].  For more information on configuring the quota, see the [documentation][quota_docs].  
-
-
-
+  You can manage quotes for individual projects on the
+  [Cloud Endpoints console][endpoints]. For more information on configuring the
+  quota, see the [documentation][quota_docs].
 
 [modelserve]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve
 [requirements]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve#requirements
@@ -173,4 +203,3 @@ The `modelserve.yaml` configuration file defines the service according to the [O
 [quota_docs]: https://cloud.google.com/endpoints/docs/openapi/quotas-configure
 
 [openapi]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
-

--- a/tutorials/appengine-serve-machine-learning-model/index.md
+++ b/tutorials/appengine-serve-machine-learning-model/index.md
@@ -1,6 +1,6 @@
 ---
-title: Serve Machine Learning Model on App Engine Flex
-description: Learn how to serve a trained machine learning model with Google App Engine flex environment.
+title: Serve Machine Learning Model on App Engine Flexible Environment
+description: Learn how to serve a trained machine learning model with App Engine flexible environment.
 author: dizcology
 tags: App Engine, Cloud Endpoints, Machine Learning
 date_published: 
@@ -15,7 +15,7 @@ This tutorial takes a deeper look at the sample app [Model serve][modelserve].  
 
 ## Before you begin
 
-Follow the links in the [Requirements section][requirements] to install Google Cloud Platform SDK and enable the APIs for App Engine, Cloud Endpoints, and Google Cloud Storage.
+Follow the links in the [Requirements section][requirements] to install Google Cloud Platform SDK and enable the APIs for App Engine, Cloud Endpoints, and Cloud Storage.
 
 ## Overview
 
@@ -23,13 +23,13 @@ So you trained a machine learning model.  Now what?
 
 If the model’s performance is good enough, consider deploying it as a service to a production system where one or more clients can use it.  Some possible scenarios include:
 
-- The model needs to process requests in real time when the users are interacting with your web application while at the same time batch process interaction logs you have stored previously in a database.
+- The model needs to simultaneously process user requests from your web application in real time, and batch process interaction logs you have previously stored in a database.
 
 - The model's output is used by multiple other machine learning models in your application.
 
-[App Engine][appengine] offers rolling update, networking, and auto scaling.
+[App Engine][appengine] offers rolling updates, networking, and auto scaling.
 
-[Cloud Endpoints][endpoints] helps you monitor and manage permission and quota of the service's consumers.
+[Cloud Endpoints][endpoints] helps you monitor the service's consumers, as well as manage their permissions and quotas.
 
 You can follow the [steps of the sample app][steps] to deploy a service.  Below we will look at some key pieces of the code to understand how it works.
 
@@ -89,13 +89,13 @@ endpoints_api_service:
   config_id: CONFIG_ID
 ```
 
-The `CONFIG_ID` points to a Cloud Endpoints service deployment.  You can find all the deployments on the [Cloud Endpoints console][endpoints] under each service page's Deployment history tab.
+The `CONFIG_ID` is the configuration ID of a Cloud Endpoints service deployment.  To find existing deployments and their configuration IDs, go to the [Cloud Endpoints console][endpoints], click on the service's title, then click on the "Deployment history" tab.
 
 To deploy a service to Cloud Endpoints, we configure it with the `modelserve.yaml` file.
 
 ### [`modelserve.yaml`][modelserve.yaml]
 
-The `modelserve.yaml` configuration file defines the service according to the [OpenAPI specification][openapi].  We highlight only some of the key configurations below.
+The `modelserve.yaml` configuration file defines the service according to the [OpenAPI specification][openapi].  We highlight only some of the key settings below.
 
 - Specify the host:
 
@@ -105,7 +105,7 @@ The `modelserve.yaml` configuration file defines the service according to the [O
 
   This host means we will handle the requests with an App Engine service called `modelserve`.
 
-- Enforce authentication with API key by adding the `security` and `securityDefinitions` fields:
+- Enforce authentication with an API key by adding the `security` and `securityDefinitions` fields:
 
     ```yaml
     security:
@@ -117,7 +117,7 @@ The `modelserve.yaml` configuration file defines the service according to the [O
         in: "query"
     ```
 
-    This is optional, but allows you to grant service consumer permissions on the [Cloud Endpoints console][endpoints].  The API key must be associated to a Google Cloud Platform project.  You can create API keys on the [credentials][credentials] page.
+    This is optional, but allows you to grant service consumer permissions on the [Cloud Endpoints console][endpoints].  The API key must be associated with a Google Cloud Platform project.  You can create API keys on the [credentials][credentials] page.
 
 - Additionally, you can configure quota for each consumer at the project level.  First we specify a service level metric in order to track the number of requests:
 
@@ -137,9 +137,9 @@ The `modelserve.yaml` configuration file defines the service according to the [O
             STANDARD: 1000
   ```
 
-  This configurations declares a metric `modelserve-predict` and sets its limit to 1000 units per minutes per project.
+  This configurations declares a metric `modelserve-predict` and sets its limit to 1000 units per minute per project.
 
-  To specify the paths to which requests will be counted towards this metric, we add the following in the `paths` field:
+  Only requests to specified paths are counted towards this metric. Specify these paths by adding the following in the `paths` field:
 
   ```yaml
   paths:

--- a/tutorials/appengine-serve-machine-learning-model/index.md
+++ b/tutorials/appengine-serve-machine-learning-model/index.md
@@ -37,7 +37,7 @@ You can follow the [steps of the sample app][steps] to deploy a service.  Below 
 
 ### [`main.py`][main.py]
 
-Our app expects `POST` requests to the path `/precict`.  It will look for the value of `'X'` in the JSON data, send it to the trained model, and return the result as the value of `'y'`:
+Our app expects `POST` requests to the path `/predict`.  It will look for the value of `'X'` in the JSON data, send it to the trained model, and return the result as the value of `'y'`:
 
 ```python
 @app.route('/predict', methods=['POST'])
@@ -47,7 +47,7 @@ def predict():
     return json.dumps({'y': y}), 200
 ```
 
-Here `MODEL` is a global variable for the trained machine learning model we are serving.  To make sure it is loaded, we use the `before_first_request` decorator, which will be triggered by App Engine's health check requests:
+Here `MODEL` is a global variable for the trained machine learning model we are serving.  To make sure the model is loaded, we use the `before_first_request` decorator, which will be triggered by App Engine's health check requests:
 
 ```python
 MODEL_BUCKET = os.environ['MODEL_BUCKET']
@@ -65,7 +65,7 @@ def _load_model():
     MODEL = pickle.loads(s)
 ```
 
-We store the model as a pickled file on [Cloud Storage][storage].  To make sure the App Engine service we are deploying knows where to find the model, we pass in its bucket and file name as environment variables.  This is done in the `app.yaml` configuration file.
+We store the model as a pickled file on [Cloud Storage][storage].  To make sure the App Engine service knows where to find the model, we pass in the model's bucket and file name as environment variables.  This is done in the `app.yaml` configuration file.
 
 
 ### [`app.yaml`][app.yaml]
@@ -119,7 +119,7 @@ The `modelserve.yaml` configuration file defines the service according to the [O
 
     This is optional, but allows you to grant service consumer permissions on the [Cloud Endpoints console][endpoints].  The API key must be associated to a Google Cloud Platform project.  You can create API keys on the [credentials][credentials] page.
 
--- Additionally, you can configure quota for each consumer at the project level.  First we specify a service level metric in order to track the number of requests:
+- Additionally, you can configure quota for each consumer at the project level.  First we specify a service level metric in order to track the number of requests:
 
   ```yaml
   x-google-management:
@@ -154,6 +154,8 @@ The `modelserve.yaml` configuration file defines the service according to the [O
   Each time a `POST` request is sent to `modelserve-dot-PROJECT_ID.appspot.com/predict`, the metric `modelserve-predict` increments by 1, and each project is limited to 1000 calls per minute with the configuration above.
 
   You can manage quotes for individual projects on the [Cloud Endpoints console][endpoints].  For more information on configuring the quota, see the [documentation][quota_docs].  
+
+
 
 
 [modelserve]: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve


### PR DESCRIPTION
Accompanying tutorial for the sample app: https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/sklearn/gae_serve.

- [x] Tech writing / styleguide review - @ccarpentiere 
- [x] Formatting review for publishing - @jmdobry