### PR TITLE
Load apache after enabling modules

### DIFF
--- a/tutorials/https-load-balancing-nginx/index.md
+++ b/tutorials/https-load-balancing-nginx/index.md
@@ -151,8 +151,8 @@ HTTPS traffic:
               apt-get update
               apt-get install -y apache2
               /usr/sbin/a2ensite default-ssl
-              service apache2 reload
               /usr/sbin/a2enmod ssl
+              service apache2 reload
                   "; \
           done
 


### PR DESCRIPTION
In the "Create your load balancer backends" section, step 1 creates instances with a startup-script to install and load apache2 on each instance. However, testing Apache on each instance subsequently fails ("Connection refused") apparently because the Apache service did not load correctly. I suspect the startup script can be improved by issuing the `service apache2 reload` command AFTER the `a2enmod` command.