### PR TITLE
Update default-ssl config filename

### DIFF
--- a/tutorials/https-load-balancing-nginx/index.md
+++ b/tutorials/https-load-balancing-nginx/index.md
@@ -193,9 +193,9 @@ Next, for each instance, perform the following tasks:
 
         gcloud compute ssh [INSTANCE_NAME]
 
-1.  Edit default-ssl:
+1.  Edit default-ssl.conf:
 
-        sudo nano /etc/apache2/sites-enabled/default-ssl
+        sudo nano /etc/apache2/sites-enabled/default-ssl.conf
 
 1.  Find the following lines:
 


### PR DESCRIPTION
I could not find the file named default-ssl on my instances; turns out it is named default-ssl.conf.