### PR TITLE
Fix config import path in Cloud Functions auto-deployer tutorial

### DIFF
--- a/tutorials/cloud-functions-github-auto-deployer/auto-deployer/index.js
+++ b/tutorials/cloud-functions-github-auto-deployer/auto-deployer/index.js
@@ -10,7 +10,7 @@ const storage = require('@google-cloud/storage')();
 const zipFolder = require('zip-folder');
 
 // config.json contain all the required information for code running
-const config = require('./config2.json');
+const config = require('./config.json');
 
 const bucket = storage.bucket(config.stageBucket);
 const PROJECT_ID = process.env.GCLOUD_PROJECT;


### PR DESCRIPTION
I found this after trying to deploy the function in this tutorial and seeing:

`Error: Cannot find module './config2.json'`.

