### PR TITLE
Update Elixir-Kubernetes tutorial with new name for container engine API.

### DIFF
--- a/tutorials/elixir-phoenix-on-kubernetes-google-container-engine/index.md
+++ b/tutorials/elixir-phoenix-on-kubernetes-google-container-engine/index.md
@@ -47,7 +47,7 @@ an existing project.
 1.  Go to the [API Library](https://console.cloud.google.com/apis/library) in
     the Cloud Console. Use it to enable the following APIs:
     *   Google Cloud Container Builder API
-    *   Google Container Engine API
+    *   Google Kubernetes Engine API
 
 Perform the installations:
 


### PR DESCRIPTION
This contains an update to the tutorial "Run an Elixir Phoenix app on Kubernetes using Google Container Engine". It changes the phrase "Google Container Engine API" -> "Google Kubernetes Engine API".