### PR TITLE
Simplify setup steps for Express on App Engine tutorial.

### DIFF
--- a/tutorials/run-expressjs-on-google-app-engine.md
+++ b/tutorials/run-expressjs-on-google-app-engine.md
@@ -28,6 +28,12 @@ Platform.
 1. Initialize a `package.json` file with the following command:
 
         npm init
+        
+1. Add a start script to your `package.json` file:
+
+        "scripts": {
+          "start": "node server.js"
+        }
 
 1. Install Express.js:
 

--- a/tutorials/run-expressjs-on-google-app-engine.md
+++ b/tutorials/run-expressjs-on-google-app-engine.md
@@ -22,6 +22,7 @@ Platform.
 1. Create a project in the [Google Cloud Platform Console](https://console.cloud.google.com/).
 1. Enable billing for your project.
 1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/).
+1. Install [Node.js](https://nodejs.org/en/download/) on your local machine. 
 
 ## Prepare
 

--- a/tutorials/run-expressjs-on-google-app-engine.md
+++ b/tutorials/run-expressjs-on-google-app-engine.md
@@ -32,7 +32,7 @@ Platform.
 1. Add a start script to your `package.json` file:
 
         "scripts": {
-          "start": "node server.js"
+          "start": "node index.js"
         }
 
 1. Install Express.js:
@@ -41,7 +41,7 @@ Platform.
 
 ## Create
 
-Create a `server.js` file with the following contents:
+Create an `index.js` file with the following contents:
 
     const express = require('express');
     const app = express();


### PR DESCRIPTION
## Context
The goal of the _Run Express.js on Google App Engine_ tutorial is to create a very simple "Hello World" example without assuming much user knowledge. The deployed tutorial page in question can be found [here](https://cloud.google.com/community/tutorials/run-expressjs-on-google-app-engine).

A. Users start with `npm init` and are given no guidance on how to use the interactive CLI. Most users will use the CLI's suggested defaults, which means that the application will set the entry point to `index.js`.

B. Before deployment, users are encouraged to use `npm start`, then open localhost:8080 to see their "Hello World" example. The instructions, however, do no provide instructions for adding such a command to the `package.json` file. `npm init` does not automatically add this command.

C. Additionally, if users do not already have Node.js installed on their machine, they will not be able to complete any of the steps using npm or run the program locally.

## Explanation of Changes

A. Rather than doing a full tutorial on how to do `npm init`, assume that users will user mostly defaults. This means that the tutorial should use `index.js` as the naming convention instead of `server.js`, as it suggests now. The tutorial now suggests users create a file name `index.js` for to hold their basic server code.

B. Users should be encourages to test their code locally by running a Node.js server. The tutorial already does this by asking users to type `npm start`. There is no default start script in `package.json`, so users should be minimally instructed on how to add this script themselves. The start script should reference `index.js`, which users will create in later tutorial steps.

C. This tutorial will not work locally unless Node.js is already installed on the user's machine. Node.js comes with npm. If we're covering all of our bases for a basic "Hello World" Node.js example, this might be the most important prerequisite.

## Summary of  Changes (tl;dr)

A. Assuming users utilized the default `index.js` entry point during `npm init`, change tutorial references from `server.js` to `index.js`

B. After `npm init`, show users how to add `npm start` script

C. Add installation of Node.js to the Prerequisites section
