### PR TITLE
Replace "Container Engine" by "Kubernetes Engine".

### DIFF
--- a/tutorials/continuous-deployment-pipeline-google-container-engine-with-codeship/index.md
+++ b/tutorials/continuous-deployment-pipeline-google-container-engine-with-codeship/index.md
@@ -1,12 +1,12 @@
 ---
-title: Continuous Deployment Pipeline to Google Container Engine using Codeship
-description: Learn how to create a continuous deployment pipeline to Container Engine from Codeship.
+title: Continuous Deployment Pipeline to Google Kubernetes Engine using Codeship
+description: Learn how to create a continuous deployment pipeline to Kubernetes Engine from Codeship.
 author: kellyjandrews
-tags: CD, Container Engine, Codeship, Pipeline
+tags: CD, Kubernetes Engine, Codeship, Pipeline
 date_published: 2017-08-28
 ---
 This tutorial explains how to create a Continuous Deployment
-pipeline to Google Container Engine using Codeship. You will
+pipeline to Google Kubernetes Engine using Codeship. You will
 learn how to deploy a containerized application when new code is merged into the
 master branch and all integration tests have passed.
 
@@ -17,9 +17,9 @@ regulatory constraints.
 
 ## Before you begin
 
-Take the following steps to enable the Google Container Engine API:
+Take the following steps to enable the Google Kubernetes Engine API:
 
-1.  Visit the [Container Engine](https://console.cloud.google.com/projectselector/kubernetes)
+1.  Visit the [Kubernetes Engine](https://console.cloud.google.com/projectselector/kubernetes)
     page in the Google Cloud Platform Console.
 1.  Create or select a project.
 1.  Wait for the API and related services to be enabled, which can take several
@@ -42,7 +42,7 @@ Make sure you have the following:
 ### Step 1: Create service account
 
 The interactions with the Google Cloud Platform API from Codeship require a service
-account with permissions to the Cloud Storage and Container Engine services.
+account with permissions to the Cloud Storage and Kubernetes Engine services.
 
 Follow these steps to create a service account:
 
@@ -54,7 +54,7 @@ Follow these steps to create a service account:
 1.  Click `Select a Role` and choose the following permissions:
 
     * Project &rarr; Service Account Actor
-    * Container &rarr; Container Engine Developer
+    * Container &rarr; Kubernetes Engine Developer
     * Storage &rarr; Storage Admin
 
 1.  Select `Furnish a new private key` and leave the option on `JSON`.
@@ -88,7 +88,7 @@ Save the `.env` file once these items are finished.
 
 ### Step 3: Run initial deployment
 
-You need to create your clusters and push an image in Container Engine initially before you
+You need to create your clusters and push an image in Kubernetes Engine initially before you
 can set up a fully automated pipeline in Codeship.
 
 Create your container clusters using the Google Cloud SDK by running the following command:
@@ -152,7 +152,7 @@ Codeship Jet CLI.
 
 This pipeline runs each step in series. The `build-image` step instructs Codeship to build the `hello-express` Docker image on the CI server. After Codeship builds the Docker image, the `push-image-with-sha` step will push the image to Google Container Registry using the name `gcr.io/YOUR_PROJECT_ID/hello-express`, adding a tag using the first 8 characters of the commit SHA for every commit to the repository.
 
-The third and fourth step will run only if the branch is tagged as `master`. The `tag-as-master` step will add the `master` tag to the image pushed to Google Container Registry. This indicates the image in Google Container Registry that is currently deployed. The following step, `gke-initial-deployment`, builds the Container Engine cluster and deploys the `gcr.io/YOUR_PROJECT_ID/hello-express` Docker image.
+The third and fourth step will run only if the branch is tagged as `master`. The `tag-as-master` step will add the `master` tag to the image pushed to Google Container Registry. This indicates the image in Google Container Registry that is currently deployed. The following step, `gke-initial-deployment`, builds the Kubernetes Engine cluster and deploys the `gcr.io/YOUR_PROJECT_ID/hello-express` Docker image.
 
 You will run this pipeline locally using the [Codeship Jet CLI](https://documentation.codeship.com/pro/builds-and-configuration/cli/). Since there is no git commit or branch to reference, use the `ci-commit-id` and `tag` flags with the Codeship Jet CLI to pass in test strings at runtime, (for example, `1234ABCD` and `master`). The build on the Codeship CI server populates `ci-commit-id` with the git commit SHA, and `tag` with the branch or tag name. Finally, the `--push` flag instructs the Codeship Jet CLI to run the push steps in the `codeship-steps.yml` file.  
 

--- a/tutorials/developing-services-with-k8s.md
+++ b/tutorials/developing-services-with-k8s.md
@@ -1,19 +1,19 @@
 ---
-title: Locally developing microservices with Google Container Engine
-description: Learn how to set up a dev environment that lets you code/test changes locally, while connecting to other services running in Google Container Engine.
+title: Locally developing microservices with Google Kubernetes Engine
+description: Learn how to set up a dev environment that lets you code/test changes locally, while connecting to other services running in Google Kubernetes Engine.
 author: richarddli
-tags: microservices, Container Engine, telepresence, PHP, Redis
+tags: microservices, Kubernetes Engine, telepresence, PHP, Redis
 date_published: 2017-04-05
 ---
 
-# Locally developing microservices with Google Container Engine
+# Locally developing microservices with Google Kubernetes Engine
 
-The [guestbook](https://cloud.google.com/container-engine/docs/tutorials/guestbook) tutorial for Kubernetes shows how to get a simple PHP and Redis application running in Kubernetes, but doesn't explain how you can actually *change* the code. We'll show you how to set up a fast, productive development environment for coding on Kubernetes. In particular, we'll show how you can make changes locally on your laptop, and see those changes reflected instantly on your externally exposed IP.
+The [guestbook](https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook) tutorial for Kubernetes shows how to get a simple PHP and Redis application running in Kubernetes, but doesn't explain how you can actually *change* the code. We'll show you how to set up a fast, productive development environment for coding on Kubernetes. In particular, we'll show how you can make changes locally on your laptop, and see those changes reflected instantly on your externally exposed IP.
 
 ## Technologies used
 
 * [Kubernetes](https://kubernetes.io)
-* [Google Container Engine](https://cloud.google.com/container-engine/)
+* [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/)
 * [Telepresence](http://www.telepresence.io)
 * [PHP](http://www.php.net/) and [Redis](https://redis.io/)
 
@@ -22,7 +22,7 @@ The [guestbook](https://cloud.google.com/container-engine/docs/tutorials/guestbo
 In order to use this demo, you're going to need:
 
 * A local system running either Linux or Mac OS X
-* Access to a Kubernetes cluster (this tutorial will walk through setting up a cluster using Google Container Engine)
+* Access to a Kubernetes cluster (this tutorial will walk through setting up a cluster using Google Kubernetes Engine)
 
 ## Microservices
 
@@ -30,7 +30,7 @@ Microservices are an increasingly popular design pattern for cloud applications.
 
 One of the areas of complexity is setting up a productive development environment for microservices. In a traditional web application, a development environment may consist of a database and the actual web application. In a microservices cloud application, an individual service may depend on multiple other services. Moreover, the service may also utilize cloud resources such as Amazon RDS or Google Cloud Pub/Sub. Setting up and maintaining a development environment with multiple services and cloud resources can be a lot of work. While there are [multiple approaches to setting up a development environment for microservices](https://www.datawire.io/guide/deployment/development-environments-microservices/), this tutorial will walk through setting up a local development environment for microservices with your services running on a remote Kubernetes cluster.
 
-In this tutorial, we're going to use the [Guestbook](https://cloud.google.com/container-engine/docs/tutorials/guestbook) sample application to illustrate a simple "microservices" architecture: the PHP service will represent one service, and the Redis database will represent another.
+In this tutorial, we're going to use the [Guestbook](https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook) sample application to illustrate a simple "microservices" architecture: the PHP service will represent one service, and the Redis database will represent another.
 
 ### Setting up your local laptop
 
@@ -42,7 +42,7 @@ First, install the `gcloud` and `kubectl` command line tools. Follow the instruc
 % sudo gcloud components update kubectl
 ```
 
-We need to install Telepresence, which will proxy your locally running service to Container Engine (for the latest installation instructions and documentation, visit [the Telepresence website](http://www.telepresence.io)).
+We need to install Telepresence, which will proxy your locally running service to Kubernetes Engine (for the latest installation instructions and documentation, visit [the Telepresence website](http://www.telepresence.io)).
 
 On OS X:
 
@@ -82,11 +82,11 @@ Finally, this tutorial uses a number of Kubernetes configuration files. To save 
 
 All example files are in the [`examples/guestbook`](https://github.com/datawire/telepresence/tree/master/examples/guestbook) directory.
 
-### Setting up Kubernetes in Google Container Engine
+### Setting up Kubernetes in Google Kubernetes Engine
 
-Setting up a production-ready Kubernetes cluster can be fairly complex, so we're going to use Google Container Engine in our example. If you already have a Kubernetes cluster handy, you can skip this section.
+Setting up a production-ready Kubernetes cluster can be fairly complex, so we're going to use Google Kubernetes Engine in our example. If you already have a Kubernetes cluster handy, you can skip this section.
 
-To set up a Kubernetes cluster in Container Engine, go to [https://console.cloud.google.com](https://console.cloud.google.com), choose the Google Container Engine option from the menu, and then Create a Cluster.
+To set up a Kubernetes cluster in Kubernetes Engine, go to [https://console.cloud.google.com](https://console.cloud.google.com), choose the Google Kubernetes Engine option from the menu, and then Create a Cluster.
 
 The following gcloud command will create a small 2 node cluster in the us-central1-a region:
 
@@ -176,7 +176,7 @@ What's going on behind the scenes? Your incoming request goes to the load balanc
 * [Setting up a Python development environment for Docker](http://matthewminer.com/2015/01/25/docker-dev-environment-for-web-app.html) covers how to configure your Docker image for hot reload
 * [Doing the same for NodeJS](http://fostertheweb.com/2016/02/nodemon-inside-docker-container/)
 * The [Microservices Architecture Guide](https://www.datawire.io/guide) covers design patterns and HOWTOs in setting up an end-to-end microservices infrastructure
-* The [Kubernetes tutorial](https://kubernetes.io/docs/tutorials/kubernetes-basics/) gives a good walk-through of using Kubernetes, or visit the [Google Container Engine Quickstart](https://cloud.google.com/container-engine/docs/quickstart)
+* The [Kubernetes tutorial](https://kubernetes.io/docs/tutorials/kubernetes-basics/) gives a good walk-through of using Kubernetes, or visit the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart)
 
 ## Conclusion
 

--- a/tutorials/elixir-phoenix-on-google-compute-engine/index.md
+++ b/tutorials/elixir-phoenix-on-google-compute-engine/index.md
@@ -9,7 +9,7 @@ date_published: 2017-11-01
 This tutorial helps you get started deploying your
 [Elixir](http://elixir-lang.org/) app using the
 [Phoenix](http://phoenixframework.org/) Framework to
-[Google Compute Engine](https://cloud.google.com/container-engine/), taking
+[Google Compute Engine](https://cloud.google.com/kubernetes-engine/), taking
 advantage of Google's deep expertise with scalable infrastructure.
 
 In this tutorial, you will:

--- a/tutorials/elixir-phoenix-on-google-compute-engine/index.md
+++ b/tutorials/elixir-phoenix-on-google-compute-engine/index.md
@@ -9,7 +9,7 @@ date_published: 2017-11-01
 This tutorial helps you get started deploying your
 [Elixir](http://elixir-lang.org/) app using the
 [Phoenix](http://phoenixframework.org/) Framework to
-[Google Compute Engine](https://cloud.google.com/kubernetes-engine/), taking
+[Google Compute Engine](https://cloud.google.com/compute/), taking
 advantage of Google's deep expertise with scalable infrastructure.
 
 In this tutorial, you will:

--- a/tutorials/elixir-phoenix-on-kubernetes-google-container-engine/index.md
+++ b/tutorials/elixir-phoenix-on-kubernetes-google-container-engine/index.md
@@ -2,7 +2,7 @@
 title: Run an Elixir Phoenix app in containers using Google Kubernetes Engine
 description: Learn how to deploy a Phoenix app in containers using Google Kubernetes Engine.
 author: dazuma
-tags: Kubernetes, Container Engine, Elixir, Phoenix, Docker
+tags: Kubernetes, Kubernetes Engine, Elixir, Phoenix, Docker
 date_published: 2017-11-01
 ---
 
@@ -11,7 +11,7 @@ This tutorial helps you get started deploying your
 [Phoenix](http://phoenixframework.org/) Framework to
 [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/),
 Google's hosting solution for containerized applications. Kubernetes Engine,
-earlier known as Google Container Engine, is based on the popular open-source
+earlier known as Google Kubernetes Engine, is based on the popular open-source
 [Kubernetes](https://kubernetes.io/) system, and leverages Google's deep
 expertise with container-based deployments.
 

--- a/tutorials/envoy-flask-google-container-engine.md
+++ b/tutorials/envoy-flask-google-container-engine.md
@@ -1,14 +1,14 @@
 ---
-title: Deploying Envoy with a Python Flask webapp and Google Container Engine
-description: Learn how to use Envoy in Google Container Engine as a foundation for adding resilience and observability to a microservices-based application.
+title: Deploying Envoy with a Python Flask webapp and Google Kubernetes Engine
+description: Learn how to use Envoy in Google Kubernetes Engine as a foundation for adding resilience and observability to a microservices-based application.
 author: flynn
-tags: microservices, Container Engine, Envoy, Flask, Python
+tags: microservices, Kubernetes Engine, Envoy, Flask, Python
 date_published: 2017-06-28
 ---
 
 One of the recurring problems with using microservices is managing communications. Your clients must be able to speak to your services, and in most cases services need to speak among themselves. When things go wrong, the system as a whole needs to be resilient, so it degrades gracefully instead of catastrophically. It also must be observable so you can figure out what's wrong.
 
-A useful pattern is to enlist a proxy, like [Envoy](https://lyft.github.io/envoy/), to help [make your application more resilient and observable](https://www.datawire.io/guide/traffic/getting-started-lyft-envoy-microservices-resilience/). Envoy can be a bit daunting to set up, so this tutorial walks you through deploying a Python Flask webapp with Envoy on Google Container Engine.
+A useful pattern is to enlist a proxy, like [Envoy](https://lyft.github.io/envoy/), to help [make your application more resilient and observable](https://www.datawire.io/guide/traffic/getting-started-lyft-envoy-microservices-resilience/). Envoy can be a bit daunting to set up, so this tutorial walks you through deploying a Python Flask webapp with Envoy on Google Kubernetes Engine.
 
 ## The Application
 
@@ -19,21 +19,21 @@ The application is a simple REST-based user service. It can create, fetch, and d
 * It lets you explore Envoy at the edge, where the user’s client talks to your application.
 * It lets you explore Envoy internally, brokering communications between the various parts of the application.
 
-Envoy runs as a sidecar, so it's language-agnostic. For this tutorial, the REST service uses Python and Flask, with PostgreSQL for persistence, all of which play nicely together. And of course, running on Container Engine means managing everything with Kubernetes.
+Envoy runs as a sidecar, so it's language-agnostic. For this tutorial, the REST service uses Python and Flask, with PostgreSQL for persistence, all of which play nicely together. And of course, running on Kubernetes Engine means managing everything with Kubernetes.
 
 ## Before you begin
 
-### Container Engine
+### Kubernetes Engine
 
-You need a Google Cloud Platform account to set up a Container Engine cluster. Visit the [Google Cloud Platform Console](https://console.cloud.google.com/kubernetes) and use the UI to create a new cluster. Picking the defaults should be fine for this tutorial.
+You need a Google Cloud Platform account to set up a Kubernetes Engine cluster. Visit the [Google Cloud Platform Console](https://console.cloud.google.com/kubernetes) and use the UI to create a new cluster. Picking the defaults should be fine for this tutorial.
 
 ### Kubernetes
 
-You need `kubectl`, the Kubernetes CLI, to work with Container Engine. On a Mac you can use `brew install kubernetes-cli`. Otherwise, follow the [Kubernetes installation intructions](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+You need `kubectl`, the Kubernetes CLI, to work with Kubernetes Engine. On a Mac you can use `brew install kubernetes-cli`. Otherwise, follow the [Kubernetes installation intructions](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 ### Docker
 
-Container Engine runs code from Docker images, so you need the Docker CLI, `docker`, to build your own images. [Docker Community Edition](https://www.docker.com/community-edition) is fine if you're just getting started (again, on a Mac, the easy way is to run `brew install docker`).
+Kubernetes Engine runs code from Docker images, so you need the Docker CLI, `docker`, to build your own images. [Docker Community Edition](https://www.docker.com/community-edition) is fine if you're just getting started (again, on a Mac, the easy way is to run `brew install docker`).
 
 ### The application
 
@@ -56,7 +56,7 @@ Between Python code, Kubernetes configs, docs, and so on, there’s too much to 
 
 ## The Docker registry
 
-Because Kubernetes needs to pull Docker images to run in its containers, you must push the Docker images used in this article to a Docker registry that Container Engine can access. For example, `gcr.io` or `dockerhub` will work fine, but for production use you might want to minimize traffic across boundaries as a cost-reduction effort.
+Because Kubernetes needs to pull Docker images to run in its containers, you must push the Docker images used in this article to a Docker registry that Kubernetes Engine can access. For example, `gcr.io` or `dockerhub` will work fine, but for production use you might want to minimize traffic across boundaries as a cost-reduction effort.
 
 Whatever you set up, you need to push to the correct registry, and you need to use the correct registry when telling Kubernetes where to go for images. Unfortunately, `kubectl` doesn't have a provision for parameterizing the YAML files it uses to figure out what to do, so `envoy-steps` contains scripts to set things up correctly.
 
@@ -178,7 +178,7 @@ Starting with `LoadBalancer` may seem odd. After all, the goal is to use Envoy t
 
 First things first: make sure it works without Envoy before moving on. You need the IP address and mapped port number for the `usersvc` service. 
 
-1. Using Container Engine, the following will build a neatly-formed URL to the load balancer created for the `usersvc`:
+1. Using Kubernetes Engine, the following will build a neatly-formed URL to the load balancer created for the `usersvc`:
 
         USERSVC_IP=$(kubectl get svc usersvc -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
         USERSVC_PORT=$(kubectl get svc usersvc -o jsonpath='{.spec.ports[0].port}')

--- a/tutorials/managing-gcp-projects-with-terraform/index.md
+++ b/tutorials/managing-gcp-projects-with-terraform/index.md
@@ -8,7 +8,7 @@ date_published: 2017-06-19
 
 Dan Isla | Google Cloud Solution Architect | Google
 
-This tutorial demonstrates how to create and manage projects on Google Cloud Platform with Terraform. With Terraform, many of your resources such as projects, IAM policies, networks, Compute Engine instances, and Container Engine clusters can be managed, versioned, and easily recreated for your organization or teams. The state that Terraform generates is saved to Google Cloud Storage for persistence.
+This tutorial demonstrates how to create and manage projects on Google Cloud Platform with Terraform. With Terraform, many of your resources such as projects, IAM policies, networks, Compute Engine instances, and Kubernetes Engine clusters can be managed, versioned, and easily recreated for your organization or teams. The state that Terraform generates is saved to Google Cloud Storage for persistence.
 
 ## Objectives
 

--- a/tutorials/modular-load-balancing-with-terraform/index.md
+++ b/tutorials/modular-load-balancing-with-terraform/index.md
@@ -19,7 +19,7 @@ This tutorial will demonstrate how to use the GCP Terraform modules for load bal
 - Learn about the load balancing modules for Terraform.
 - Create a regional TCP load balancer.
 - Create a regional internal TCP load balancer.
-- Create a global HTTP load balancer with Container Engine.
+- Create a global HTTP load balancer with Kubernetes Engine.
 - Create a global HTTPS content-based load balancer.
 
 ## Before you begin

--- a/tutorials/run-botkit-on-google-container-engine/index.md
+++ b/tutorials/run-botkit-on-google-container-engine/index.md
@@ -1,13 +1,13 @@
 ---
-title: Running a Botkit Slack Bot on Google Container Engine
-description: Learn how to run a Botkit Slack bot on Google Container Engine.
+title: Running a Botkit Slack Bot on Google Kubernetes Engine
+description: Learn how to run a Botkit Slack bot on Google Kubernetes Engine.
 author: tswast
-tags: Container Engine, Node.js, Botkit, Slack
+tags: Kubernetes Engine, Node.js, Botkit, Slack
 date_published: 2017-02-03
 ---
 This tutorial shows how to build a [Slack bot](https://api.slack.com/bot-users)
 using the [Botkit toolkit](https://howdy.ai/botkit/) and run it on [Google
-Container Engine](https://cloud.google.com/container-engine/).
+Kubernetes Engine](https://cloud.google.com/kubernetes-engine/).
 
 You will build a "Hello World" Slack bot which responds with a greeting in
 response to messages.
@@ -17,14 +17,14 @@ response to messages.
 1. Create a bot internal integration in Slack.
 1. Build a Node.js image in Docker.
 1. Upload a Docker image to a private Google Container Registry.
-1. Run a Slack bot on Google Container Engine.
+1. Run a Slack bot on Google Kubernetes Engine.
 
 ## Costs
 
 This tutorial uses billable components of Google Cloud Platform, including:
 
-- Google Container Engine
-- Google Compute Engine (via Google Container Engine)
+- Google Kubernetes Engine
+- Google Compute Engine (via Google Kubernetes Engine)
 - Google Cloud Storage (via the Google Container Registry)
 
 Use the [Pricing Calculator][pricing] to generate a cost estimate based on your
@@ -237,7 +237,7 @@ If all goes well, you should be able to see the container image listed in the
 Your Docker image is now published to your private repository, which
 Kubernetes can access and orchestrate.
 
-## Deploying a bot to Container Engine
+## Deploying a bot to Kubernetes Engine
 
 Now that the Docker image is in Google Container Registry, you can run the
 [`gcloud docker -- pull`
@@ -254,9 +254,9 @@ of your bot running, and the Kubernetes master will keep that target state. It
 starts the bot up when there aren't enough running, and shuts bot replicas down
 when there are too many.
 
-### Creating a Kubernetes cluster with Container Engine
+### Creating a Kubernetes cluster with Kubernetes Engine
 
-A Container Engine cluster is a managed Kubernetes cluster. It consists of a
+A Kubernetes Engine cluster is a managed Kubernetes cluster. It consists of a
 Kubernetes master API server hosted by Google and a set of worker nodes. The
 worker nodes are Compute Engine virtual machines.
 
@@ -272,7 +272,7 @@ will take a few minutes to complete):
 Alternatively, you could create this cluster [via the Cloud
 Console](https://console.cloud.google.com/kubernetes/add).
 
-### Deploying to Container Engine
+### Deploying to Kubernetes Engine
 
 Kubernetes has a [Secrets](https://kubernetes.io/docs/user-guide/secrets/#creating-a-secret-using-kubectl-create-secret)
 API for storing secret information such as passwords that containers need at
@@ -316,7 +316,7 @@ pending](https://kubernetes.io/docs/user-guide/debugging-pods-and-replication-co
 
 ## Cleaning up
 
-Congratulations, you now have a Slack bot running on Google Container Engine.
+Congratulations, you now have a Slack bot running on Google Kubernetes Engine.
 
 You can follow these steps to clean up resources and save on costs.
 

--- a/tutorials/run-spring-petclinic-on-app-engine-cloudsql/index.md
+++ b/tutorials/run-spring-petclinic-on-app-engine-cloudsql/index.md
@@ -202,7 +202,7 @@ https://YOUR_PROJECT_ID.appspot.com.
 ### Next steps
 
 - [Build][build] your own Spring application.
-- Deploy the application to [Google Container Engine][gke].
+- Deploy the application to [Google Kubernetes Engine][gke].
 - Try out [other Java samples][samples] on GCP.
 
 [source-path]: https://github.com/GoogleCloudPlatform/community/tree/master/tutorials/run-spring-petclinic-on-app-engine-cloudsql/spring-petclinic

--- a/tutorials/running-nodejs-on-google-cloud.md
+++ b/tutorials/running-nodejs-on-google-cloud.md
@@ -2,7 +2,7 @@
 title: Node.js and Google Cloud Platform
 description: Get an overview of Node.js and learn ways to run Node.js apps on Google Cloud Platform.
 author: jmdobry
-tags: Node.js, Compute Engine, Container Engine, App Engine, Cloud Functions
+tags: Node.js, Compute Engine, Kubernetes Engine, App Engine, Cloud Functions
 date_published: 2016-12-14
 ---
 This tutorial shows how to prepare your computer for [Node.js][nodejs]
@@ -85,7 +85,7 @@ There are four options for running Node.js applications on Google Cloud
 Platform:
 
 * [Google Compute Engine][gce]
-* [Google Container Engine][gke]
+* [Google Kubernetes Engine][gke]
 * [Google App Engine flexible environment][gae]
 * [Google Cloud Functions][gcf]
 
@@ -98,10 +98,10 @@ machines running in Google's innovative data centers and worldwide fiber
 network. Compute Engine's tooling and workflow support enable scaling from
 single instances to global, load-balanced cloud computing.
 
-### Node.js on Container Engine
+### Node.js on Kubernetes Engine
 
-[Container Engine][gke] is a powerful cluster manager and orchestration system
-for running your Docker containers. Container Engine schedules your containers
+[Kubernetes Engine][gke] is a powerful cluster manager and orchestration system
+for running your Docker containers. Kubernetes Engine schedules your containers
 into the cluster and manages them automatically based on requirements you define
 (such as CPU and memory). It's built on the open source [Kubernetes][k8s]
 system, giving you the flexibility to take advantage of on-premises, hybrid, or
@@ -132,7 +132,7 @@ more about [Node.js on Google Cloud Platform][nodejs-gcp].
 [nodejs-dev]: how-to-prepare-a-nodejs-dev-environment
 [inspect]: https://nodejs.org/api/debugger.html#debugger_v8_inspector_integration_for_node_js
 [gce]: https://cloud.google.com/compute/
-[gke]: https://cloud.google.com/container-engine/
+[gke]: https://cloud.google.com/kubernetes-engine/
 [k8s]: http://kubernetes.io/
 [gae]: https://cloud.google.com/appengine/docs/flexible/nodejs/
 [gcf]: https://cloud.google.com/functions/

--- a/tutorials/transparent-proxy-and-filtering-on-k8s-with-initializers/index.md
+++ b/tutorials/transparent-proxy-and-filtering-on-k8s-with-initializers/index.md
@@ -20,7 +20,7 @@ Just like in the previous tutorial, the purpose of the [tproxy-sidecar](https://
 
 ## Objectives
 
-- Create a Kubernetes cluster with initializer and RBAC support using Google Container Engine
+- Create a Kubernetes cluster with initializer and RBAC support using Google Kubernetes Engine
 - Deploy the tproxy, tproxy-initializer and the tproxy-podwatch pods using Helm
 - Deploy example apps with annotations to test external access to a Google Cloud Storage bucket
 
@@ -32,7 +32,7 @@ This tutorial assumes you already have a Google Cloud Platform (GCP) account and
 
 This tutorial uses billable components of GCP, including:
 
-- [Google Container Engine](https://cloud.google.com/container-engine/pricing)
+- [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/pricing)
 
 Use the [Pricing Calculator](https://cloud.google.com/products/calculator/#id=f52c2651-4b02-4da3-b8cd-fdbca6ad89a9) to estimate the costs for your environment.
 
@@ -47,9 +47,9 @@ Use the [Pricing Calculator](https://cloud.google.com/products/calculator/#id=f5
 
     The remainder of this tutorial will be run from the root of the cloned repository directory.
 
-## Create Container Engine cluster and install Helm
+## Create Kubernetes Engine cluster and install Helm
 
-1. Create Container Engine cluster with alpha features enabled, RBAC support, and a cluster version of at least 1.7 to support initializers:
+1. Create Kubernetes Engine cluster with alpha features enabled, RBAC support, and a cluster version of at least 1.7 to support initializers:
 
         gcloud container clusters create tproxy-example \
           --zone us-central1-f \
@@ -198,7 +198,7 @@ Deploy the sample apps to demonstrate using and not using the annotation to trig
 
         helm delete --purge tproxy
 
-3. Delete the Container Engine cluster:
+3. Delete the Kubernetes Engine cluster:
 
         gcloud container clusters delete tproxy-example --zone=us-central1-f
 

--- a/tutorials/transparent-proxy-and-filtering-on-k8s/index.md
+++ b/tutorials/transparent-proxy-and-filtering-on-k8s/index.md
@@ -24,7 +24,7 @@ This tutorial uses the [tproxy-sidecar](https://github.com/danisla/kubernetes-tp
 
 ## Objectives
 
-- Create a Kubernetes cluster with Google Container Engine.
+- Create a Kubernetes cluster with Google Kubernetes Engine.
 - Deploy the tproxy and the tproxy-podwatch pods using Helm.
 - Deploy example apps to test external access to a Cloud Storage bucket.
 
@@ -36,7 +36,7 @@ This tutorial assumes you already have a Google Cloud Platform (GCP) account and
 
 This tutorial uses billable components of GCP, including:
 
-- [Google Container Engine](https://cloud.google.com/container-engine/pricing)
+- [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/pricing)
 
 Use the [Pricing Calculator](https://cloud.google.com/products/calculator/#id=f52c2651-4b02-4da3-b8cd-fdbca6ad89a9) to estimate the costs for your environment.
 
@@ -51,9 +51,9 @@ Use the [Pricing Calculator](https://cloud.google.com/products/calculator/#id=f5
 
     The remainder of this tutorial will be run from the root of the cloned repository directory.
 
-## Create Container Engine cluster and install Helm
+## Create Kubernetes Engine cluster and install Helm
 
-1. Create the Container Engine cluster:
+1. Create the Kubernetes Engine cluster:
 
         gcloud container clusters create tproxy-example --zone us-central1-f
 
@@ -235,7 +235,7 @@ This tutorial uses a Python script to filter traffic to a specific Cloud Storage
 
         helm delete --purge tproxy
 
-3. Delete the Container Engine cluster:
+3. Delete the Kubernetes Engine cluster:
 
         gcloud container clusters delete tproxy-example --zone=us-central1-f
 


### PR DESCRIPTION
Also rename some links to https://cloud.google.com/container-engine/ and
the service account roles, which also have changed.