### PR TITLE
Ghost on App Engine update

### DIFF
--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -184,7 +184,7 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
 1. Edit `config.production.json` and set it to the following:
 
         {
-            "url": "http://YOUR_PROJECT_ID.appspot.com",
+            "url": "https://YOUR_PROJECT_ID.appspot.com",
             "fileStorage": false,
             "mail": {},
             "database": {

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -1,7 +1,7 @@
 ---
-title: Ghost on App Engine Flexibe Environment Part 1 - Deploying
+title: Ghost on App Engine Flexible Environment Part 1 - Deploying
 description: Learn how to deploy a Ghost blog to Google App Engine flexible environment.
-author: jmdobry
+author: excelulous
 tags: App Engine, Ghost, Node.js
 date_published: 2016-05-26
 ---
@@ -120,54 +120,49 @@ from the [Cloud Console][console] or via the [Cloud SDK][sdk].
 [database]: https://cloud.google.com/sql/docs/create-database
 [sql]:  https://cloud.google.com/sql/docs/quickstart
 
-## Download Ghost
+## Install Ghost as an NPM Module
 
-1. Download Ghost:
+Follow the instructions on the Ghost website to [install Ghost as an NPM Module][ghost_npm]
 
-        curl -L https://ghost.org/zip/ghost-latest.zip -o ghost.zip
-
-1. Extract the files:
-
-        unzip -uo ghost.zip -d ./ghost
-
-1. Change directory:
-
-        cd ghost
+[ghost_npm]: https://docs.ghost.org/docs/using-ghost-as-an-npm-module
+[knex_prod]: https://docs.ghost.org/docs/using-ghost-as-an-npm-module#section-run-database-migration
 
 ## Configure
 
-Create a `config.js` file from the default config file:
+1. Create a `config.development.json` file from the default config file:
 
-    cp config.example.js config.js
+        cp node_modules/ghost/core/server/config/env/config.development.json config.development.json
+
+1. Create a `config.production.json` file from the default config file:
+
+        cp node_modules/ghost/core/server/config/env/config.production.json config.production.json
 
 ### Run the app locally
 
-1. Edit the `development` configuration in `config.js` and set it to the following:
+1. Edit `config.development.json` and set it to the following:
 
-        // Development configuration, activated when you run locally
-        development: {
-          // If you've configured a custom domain, set this to https://your-custom-domain.com
-          url: 'http://localhost:2368',
-          // Disable file storage
-          fileStorage: false,
-          // Configure email. See   http://support.ghost.org/mail/
-          mail: {},
-          // Configure Ghost to use the Cloud SQL instance
-          database: {
-            client: 'mysql',
-            connection: {
-              host: '127.0.0.1',
-              user: process.env.MYSQL_USER,
-              password: process.env.MYSQL_PASSWORD,
-              database: process.env.MYSQL_DATABASE,
-              charset  : 'utf8'
+        {
+            "url": "http://localhost:2368",
+            "fileStorage": false,
+            "mail": {},
+            "database": {
+                "client": "mysql",
+                "connection": {
+                    "host": "127.0.0.1",
+                    "user": "YOUR_MYSQL_USERNAME",
+                    "password": "YOUR_MYSQL_PASSWORD",
+                    "database": "YOUR_MYSQL_DATABASE_NAME",
+                    "charset": "utf8"
+                },
+                "debug": false
             },
-            debug: true
-          },
-          server: {
-            host: '127.0.0.1',
-            port: '2368'
-          }
+            "server": {
+                "host": "127.0.0.1",
+                "port": "2368"
+            },
+            "paths": {
+                "contentPath": "content/"
+            }
         }
 
 1. Install Dependencies:
@@ -187,35 +182,29 @@ Create a `config.js` file from the default config file:
 
 ## Deploy
 
-1. Edit the `production` configuration in `config.js` and set it to the following:
+1. Edit `config.production.json` and set it to the following:
 
-        // Production configuration, activated when deployed to App Engine
-        production: {
-          // If you've configured a custom domain, set this to https://your-custom-domain.com
-          url: 'https://' + process.env.GCLOUD_PROJECT + '.appspot.com',
-          // Disable file storage, as App Engine disks are not persistent
-          fileStorage: false,
-          // Configure email. See http://support.ghost.org/mail/
-          mail: {},
-          // Configure Ghost to use the Cloud SQL instance
-          database: {
-            client: 'mysql',
-            connection: {
-              socketPath: '/cloudsql/' + process.env.INSTANCE_CONNECTION_NAME,
-              user: process.env.MYSQL_USER,
-              password: process.env.MYSQL_PASSWORD,
-              database: process.env.MYSQL_DATABASE,
-              charset  : 'utf8'
+        {
+            "url": "YOUR_PROJECT_URL",
+            "fileStorage": false,
+            "mail": {},
+            "database": {
+                "client": "mysql",
+                "connection": {
+                    "user": "YOUR_MYSQL_USERNAME",
+                    "password": "YOUR_MYSQL_PASSWORD",
+                    "database": "YOUR_MYSQL_DATABASE_NAME",
+                    "charset": "utf8"
+                },
+                "debug": false
             },
-            debug: false
-          },
-          server: {
-            // Important. This MUST be set to 0.0.0.0
-            host: '0.0.0.0',
-            // App Engine expects the app to listen on port 8080, which is what
-            // process.env.PORT will be set to in production
-            port: process.env.PORT || '2368'
-          }
+            "server": {
+                "host": "0.0.0.0",
+                "port": "8080"
+            },
+            "paths": {
+                "contentPath": "content/"
+            }
         }
 
     Here's some information about each setting:
@@ -293,9 +282,39 @@ Create a `config.js` file from the default config file:
 
     Read more about [using `app.yaml`][appyaml].
 
+1. Migrate the database to allow use in production, with:
+
+        NODE_ENV=production knex-migrator init --mgpath node_modules/ghost
+
+1. Add `"socketPath": "/cloudsql/YOUR_INSTANCE_NAME"` in the connection properties section of your `config.production.json`, so you end up with:
+
+        {
+            "url": "YOUR_PROJECT_URL",
+            "fileStorage": false,
+            "mail": {},
+            "database": {
+                "client": "mysql",
+                "connection": {
+                    "socketPath": "/cloudsql/YOUR_INSTANCE_NAME",
+                    "user": "YOUR_MYSQL_USERNAME",
+                    "password": "YOUR_MYSQL_PASSWORD",
+                    "database": "YOUR_MYSQL_DATABASE_NAME",
+                    "charset": "utf8"
+                },
+                "debug": false
+            },
+            "server": {
+                "host": "0.0.0.0",
+                "port": "8080"
+            },
+            "paths": {
+                "contentPath": "content/"
+            }
+        }
+
 1. Run the following command to deploy the app:
 
-    gcloud app deploy
+        gcloud app deploy
 
 [scaling]: https://cloud.google.com/appengine/docs/flexible/nodejs/configuring-your-app-with-app-yaml#auto-scaling
 [resources]: https://cloud.google.com/appengine/docs/flexible/nodejs/configuring-your-app-with-app-yaml#resource-settings

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying Ghost on App Engine Flexible Environment - Part 1
 description: Learn how to deploy a Ghost blog to Google App Engine flexible environment.
-author: hnipps
+author: jmdobry,hnipps
 tags: App Engine, Ghost, Node.js
 date_published: 2016-05-26
 ---
@@ -148,9 +148,9 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
                 "client": "mysql",
                 "connection": {
                     "host": "127.0.0.1",
-                    "user": YOUR_MYSQL_USERNAME,
-                    "password": YOUR_MYSQL_PASSWORD,
-                    "database": YOUR_MYSQL_DATABASE_NAME,
+                    "user": "YOUR_MYSQL_USERNAME",
+                    "password": "YOUR_MYSQL_PASSWORD",
+                    "database": "YOUR_MYSQL_DATABASE_NAME",
                     "charset": "utf8"
                 },
                 "debug": false
@@ -190,9 +190,9 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
             "database": {
                 "client": "mysql",
                 "connection": {
-                    "user": YOUR_MYSQL_USERNAME,
-                    "password": YOUR_MYSQL_PASSWORD,
-                    "database": YOUR_MYSQL_DATABASE_NAME,
+                    "user": "YOUR_MYSQL_USERNAME",
+                    "password": "YOUR_MYSQL_PASSWORD",
+                    "database": "YOUR_MYSQL_DATABASE_NAME",
                     "charset": "utf8"
                 },
                 "debug": false

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -1,7 +1,7 @@
 ---
 title: Ghost on App Engine Flexible Environment Part 1 - Deploying
 description: Learn how to deploy a Ghost blog to Google App Engine flexible environment.
-author: excelulous
+author: jmdobry, hnipps
 tags: App Engine, Ghost, Node.js
 date_published: 2016-05-26
 ---

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -311,7 +311,7 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
             }
         }
 
-It's very important that you only do this step after migrating the database, because the socketPath property is required to deploy on GCP, but it causes knex-migrator to throw an error.
+It's very important that you only do this step after migrating the database, because the socketPath property is required to deploy on Google App Engine, but it causes knex-migrator to throw an error.
 
 1. Run the following command to deploy the app:
 

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -148,9 +148,9 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
                 "client": "mysql",
                 "connection": {
                     "host": "127.0.0.1",
-                    "user": "YOUR_MYSQL_USERNAME",
-                    "password": "YOUR_MYSQL_PASSWORD",
-                    "database": "YOUR_MYSQL_DATABASE_NAME",
+                    "user": YOUR_MYSQL_USERNAME,
+                    "password": YOUR_MYSQL_PASSWORD,
+                    "database": YOUR_MYSQL_DATABASE_NAME,
                     "charset": "utf8"
                 },
                 "debug": false
@@ -184,15 +184,15 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
 1. Edit `config.production.json` and set it to the following:
 
         {
-            "url": "YOUR_PROJECT_URL",
+            "url": "http://YOUR_PROJECT_ID.appspot.com",
             "fileStorage": false,
             "mail": {},
             "database": {
                 "client": "mysql",
                 "connection": {
-                    "user": "YOUR_MYSQL_USERNAME",
-                    "password": "YOUR_MYSQL_PASSWORD",
-                    "database": "YOUR_MYSQL_DATABASE_NAME",
+                    "user": YOUR_MYSQL_USERNAME,
+                    "password": YOUR_MYSQL_PASSWORD,
+                    "database": YOUR_MYSQL_DATABASE_NAME,
                     "charset": "utf8"
                 },
                 "debug": false
@@ -288,16 +288,16 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
 1. Add `"socketPath": "/cloudsql/YOUR_INSTANCE_NAME"` in the connection properties section of your `config.production.json`, so you end up with:
 
         {
-            "url": "YOUR_PROJECT_URL",
+            "url": "http://YOUR_PROJECT_ID.appspot.com",
             "fileStorage": false,
             "mail": {},
             "database": {
                 "client": "mysql",
                 "connection": {
                     "socketPath": "/cloudsql/YOUR_INSTANCE_NAME",
-                    "user": "YOUR_MYSQL_USERNAME",
-                    "password": "YOUR_MYSQL_PASSWORD",
-                    "database": "YOUR_MYSQL_DATABASE_NAME",
+                    "user": YOUR_MYSQL_USERNAME,
+                    "password": YOUR_MYSQL_PASSWORD,
+                    "database": YOUR_MYSQL_DATABASE_NAME,
                     "charset": "utf8"
                 },
                 "debug": false

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -125,7 +125,6 @@ from the [Cloud Console][console] or via the [Cloud SDK][sdk].
 Follow the instructions on the Ghost website to [install Ghost as an NPM Module][ghost_npm]
 
 [ghost_npm]: https://docs.ghost.org/docs/using-ghost-as-an-npm-module
-[knex_prod]: https://docs.ghost.org/docs/using-ghost-as-an-npm-module#section-run-database-migration
 
 ## Configure
 

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -1,5 +1,5 @@
 ---
-title: Ghost on App Engine Flexible Environment Part 1 - Deploying
+title: Deploying Ghost on App Engine Flexible Environment - Part 1
 description: Learn how to deploy a Ghost blog to Google App Engine flexible environment.
 author: hnipps
 tags: App Engine, Ghost, Node.js
@@ -311,7 +311,7 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
             }
         }
 
-It's very important that you only do this step after migrating the database, because the socketPath property is required to deploy on Google App Engine, but it causes knex-migrator to throw an error.
+It's very important that you only do this step after migrating the database. The ```socketPath``` property is required to deploy on Google App Engine, but it causes ```knex-migrator``` to throw an error.
 
 1. Run the following command to deploy the app:
 
@@ -329,7 +329,7 @@ It's very important that you only do this step after migrating the database, bec
 
 ## What's next
 
-[Ghost on App Engine Part 2 - Monitoring][monitoring]
+[Monitoring Ghost on App Engine Flexible Environment - Part 2][monitoring]
 
 [monitoring]: https://cloud.google.com/community/tutorials/ghost-on-app-engine-part-2-monitoring
 [ghost]: https://ghost.org/

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -122,7 +122,7 @@ from the [Cloud Console][console] or via the [Cloud SDK][sdk].
 
 ## Install Ghost as an NPM Module
 
-Follow the instructions on the Ghost website to [install Ghost as an NPM Module][ghost_npm]
+Follow the instructions on the Ghost website to [install Ghost as an NPM Module][ghost_npm].
 
 [ghost_npm]: https://docs.ghost.org/docs/using-ghost-as-an-npm-module
 
@@ -310,6 +310,8 @@ Follow the instructions on the Ghost website to [install Ghost as an NPM Module]
                 "contentPath": "content/"
             }
         }
+
+It's very important that you only do this step after migrating the database, because the socketPath property is required to deploy on GCP, but it causes knex-migrator to throw an error.
 
 1. Run the following command to deploy the app:
 

--- a/tutorials/ghost-on-app-engine-part-1-deploying.md
+++ b/tutorials/ghost-on-app-engine-part-1-deploying.md
@@ -1,7 +1,7 @@
 ---
 title: Ghost on App Engine Flexible Environment Part 1 - Deploying
 description: Learn how to deploy a Ghost blog to Google App Engine flexible environment.
-author: jmdobry, hnipps
+author: hnipps
 tags: App Engine, Ghost, Node.js
 date_published: 2016-05-26
 ---

--- a/tutorials/ghost-on-app-engine-part-2-monitoring.md
+++ b/tutorials/ghost-on-app-engine-part-2-monitoring.md
@@ -1,5 +1,5 @@
 ---
-title: Ghost on App Engine Flexible Environment Part 2 - Monitoring
+title: Monitoring Ghost on App Engine Flexible Environment - Part 2
 description: Learn how to monitor a Ghost blog running on Google App Engine flexible environment.
 author: jmdobry
 tags: App Engine, Ghost, Node.js, Stackdriver


### PR DESCRIPTION
I've updated the tutorial for deploying Ghost on Google Cloud App Engine. I tried to follow the tutorial myself, but noticed that Ghost have changed some things, notably the config files. So I updated this tutorial with the process I used to deploy.
Major changes:

- Updated example config files
- Added an extra step that involves running knex-migrator with the 'production' flag set