### PR TITLE
Simplify the PHP test

### DIFF
--- a/tutorials/setting-up-lamp/index.md
+++ b/tutorials/setting-up-lamp/index.md
@@ -114,11 +114,9 @@ look up the address in the
 
     You should see the Apache test page.
 
-1. Create a test file in the default web server root at `/var/www/html/`. You can follow the instructions in the [php documentation](http://php.net/manual/en/tutorial.firstpage.php). Example number 2 is the simplest example.
+1. Create a test PHP file in the default web server root at `/var/www/html/`. You can follow the instructions in the [php documentation](http://php.net/manual/en/tutorial.firstpage.php). Or run the following shell command to create a quick `phpinfo.php` test file.
 
-    You can write the code to the file from the command line by using a statement like the following. Replace `[YOUR_PHP_CODE]` with the code you want to write out:
-
-        sudo sh -c 'echo "[YOUR_PHP_CODE]" > /var/www/html/phpinfo.php'
+        sudo sh -c 'echo "<?php echo phpinfo(); ?>" > /var/www/html/phpinfo.php'
 
 1. Browse to the test file to verify that Apache and PHP are working together:
 


### PR DESCRIPTION
Escape characters may be required when I paste PHP code into: `sh -c 'echo "[YOUR_PHP_CODE]" > /var/www/html/phpinfo.php'`. This tripped me up and slowed down my PHP test. Also `phpinfo();` jibes with the next couple steps in that section.