### PR TITLE
Add a note about missing config/prod.secret.exs

### DIFF
--- a/tutorials/elixir-phoenix-on-kubernetes-google-container-engine/index.md
+++ b/tutorials/elixir-phoenix-on-kubernetes-google-container-engine/index.md
@@ -268,6 +268,9 @@ Execute the following command to run the build:
 Replace `${PROJECT_ID}` with the ID of your Google Cloud Platform project.
 The period at the end is required.
 
+If your `.gitignore` file is excluding `/config/*.secret.exs`,
+you'll have to comment that out for this step - we need that file.
+
 After the build finishes, the image `gcr.io/${PROJECT_ID}/hello:v1` will be
 available. You can list the images you have built in your project using:
 


### PR DESCRIPTION
My first walkthrough of this, I got this error.  I think the phoenix new template .gitignore includes this file (which is good).

```
Step 8/17 : RUN mix do deps.get, deps.compile, compile
 ---> Running in caef9afa1b97
** (Mix.Config.LoadError) could not load config config/prod.secret.exs
    ** (File.Error) could not read file "/opt/app/config/prod.secret.exs": no such file or directory
    (elixir) lib/file.ex:310: File.read!/1
    (mix) lib/mix/config.ex:189: Mix.Config.read!/2
    (mix) lib/mix/config.ex:233: anonymous fn/3 in Mix.Config.read_wildcard!/2
    (elixir) lib/enum.ex:1899: Enum."-reduce/3-lists^foldl/2-0-"/3
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:878: :erl_eval.expr_list/6
    (stdlib) erl_eval.erl:404: :erl_eval.expr/5
The command '/bin/sh -c mix do deps.get, deps.compile, compile' returned a non-zero code: 1
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: exit status 1

------------------------------------------------------------------------------------------------

ERROR: (gcloud.container.builds.submit) build 5f7cccdf-5f1d-497d-98d9-2d4b1605a716 completed with status "FAILURE"
```