### PR TITLE
Remove BETA from PostgreSQL

### DIFF
--- a/tutorials/horizontally-scale-mysql-database-backend-with-google-cloud-sql-and-proxysql/index.md
+++ b/tutorials/horizontally-scale-mysql-database-backend-with-google-cloud-sql-and-proxysql/index.md
@@ -11,7 +11,7 @@ your application using [Google Cloud SQL](https://cloud.google.com/sql) and
 [ProxySQL](http://proxysql.com).
 
 Google Cloud SQL is a fully-managed database service that makes it easy to set
-up, maintain, manage, and administer your relational PostgreSQL (BETA) and MySQL
+up, maintain, manage, and administer your relational PostgreSQL and MySQL
 databases in the cloud. Cloud SQL offers high performance, scalability, and
 convenience. Hosted on Google Cloud Platform, Cloud SQL provides a database
 infrastructure for applications running anywhere.


### PR DESCRIPTION
PostgreSQL is now out of [beta](https://cloudplatform.googleblog.com/2018/04/Cloud-SQL-for-PostgreSQL-now-generally-available-and-ready-for-your-production-workloads.html)