### PR TITLE
Add configuration for Symfony 4

### DIFF
--- a/tutorials/run-symfony-on-appengine-flexible/index.md
+++ b/tutorials/run-symfony-on-appengine-flexible/index.md
@@ -39,8 +39,9 @@ Welcome page.
 
 ## Deploy
 
-1.  Create an `app.yaml` file with the following contents:
+1.  Create an `app.yaml` file with the following contents depending on the version of Symfony that you are using:
 
+##### Symfony 2 & 3
         runtime: php
         env: flex
 
@@ -48,6 +49,18 @@ Welcome page.
           document_root: web
           front_controller_file: app.php
 
+ 
+##### Symfony 4 and above
+        runtime: php
+        env: flex
+
+        runtime_config:
+          document_root: public
+          front_controller_file: index.php
+
+        env_variables:
+            APP_ENV: "prod"
+     
 1.  Replace `post-install-cmd` in `composer.json` with the following script:
 
         "post-install-cmd": [


### PR DESCRIPTION
Symfony 4 introduced a new directory structure: http://fabien.potencier.org/symfony4-directory-structure.html renaming `web` to `public`. The front controller was also unifed from app.php & app_dev.php to index.php. The APP_DEV environment variable is also required, for symfony 4.

I think this should resolve #372 