### PR TITLE
Simplify deployment commands

### DIFF
--- a/tutorials/cloud-functions-twilio-sms/index.md
+++ b/tutorials/cloud-functions-twilio-sms/index.md
@@ -145,18 +145,15 @@ The `reply` function does the following:
 
 ## Deploying and Testing the Cloud Function
 
-1.  Read about [deploying Cloud Functions][deploying].
 1.  Run the following to deploy the function:
 
-        gcloud beta functions deploy reply --trigger-http --stage-bucket [YOUR_STAGE_BUCKET]
-
-    Replacing `[YOUR_STAGE_BUCKET]` with your Cloud Functions staging bucket.
+        gcloud functions deploy reply --trigger-http
 
 1.  Send an SMS message to your Twilio phone number and observe the response you
     receive from the Cloud Function.
 
 To view the logs for the Cloud Function, run the following:
 
-    gcloud beta functions logs view reply
+    gcloud functions logs view reply
 
 [deploying]: https://cloud.google.com/functions/docs/deploying/filesystem


### PR DESCRIPTION
Remove "beta" from the deployment commands, now that Cloud Functions are out of beta. Simplify deployment by not using a Cloud Storage bucket (which requires the user to read up on this topic in a separate doc).