### PR TITLE
Escape or transform things that look like html tags in existing content

### DIFF
--- a/tutorials/appengine-effective-polymodel.md
+++ b/tutorials/appengine-effective-polymodel.md
@@ -56,7 +56,7 @@ indicating its type in order to determine which fields are needed.
         # Computer Properties
         ghz = db.FloatProperty()
         # NOTE: The ram property is shared between camera and laptop.
-        hard_drive = db.IntegerProperty()</pre>
+        hard_drive = db.IntegerProperty()
 
 With AJAX, it's not that hard for Andreas to write forms that are customized
 based on what the customer is looking for. GQL also makes it easy to do the

--- a/tutorials/appengine-pusher/index.md
+++ b/tutorials/appengine-pusher/index.md
@@ -172,12 +172,12 @@ public class AuthorizeServlet extends HttpServlet {
 	String query = CharStreams.toString(request.getReader());
 	// socket_id, channel_name parameters are automatically set in the POST body of the request
 	// eg.socket_id=1232.12&channel_name=presence-my-channel
-	Map<String, String> data = splitQuery(query);
+	Map&lt;String, String&gt; data = splitQuery(query);
 	String socketId = data.get("socket_id");
 	String channelId = data.get("channel_name");
 
 	// Presence channels (presence-*) require user identification for authentication
-	Map<String, String> userInfo = new HashMap<>();
+	Map&lt;String, String&gt; userInfo = new HashMap<>();
 	userInfo.put("displayName", displayName);
 
 	// Inject custom authentication code for your application here to allow/deny current request
@@ -193,8 +193,8 @@ public class AuthorizeServlet extends HttpServlet {
 	response.getWriter().append(auth);
   }
 
-  private static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
-	Map<String, String> query_pairs = new HashMap<>();
+  private static Map&lt;String, String&gt; splitQuery(String query) throws UnsupportedEncodingException {
+	Map&lt;String, String&gt; query_pairs = new HashMap<>();
 	String[] pairs = query.split("&");
 	for (String pair : pairs) {
 	  int idx = pair.indexOf("=");
@@ -226,8 +226,8 @@ documentation.
 public class SendMessageServlet extends HttpServlet {
 
   private Gson gson = new GsonBuilder().create();
-  private TypeReference<Map<String, String>> typeReference =
-	  new TypeReference<Map<String, String>>() {};
+  private TypeReference&lt;Map&lt;String, String&gt;&gt; typeReference =
+	  new TypeReference&lt;Map&lt;String, String&gt;&gt;() {};
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -236,7 +236,7 @@ public class SendMessageServlet extends HttpServlet {
 
 	String body = CharStreams.readLines(request.getReader()).toString();
 	String json = body.replaceFirst("^\\[", "").replaceFirst("\\]$", "");
-	Map<String, String> data = gson.fromJson(json, typeReference.getType());
+	Map&lt;String, String&gt; data = gson.fromJson(json, typeReference.getType());
 	String message = data.get("message");
 	String socketId = data.get("socket_id");
 	String channelId = data.get("channel_id");
@@ -246,8 +246,8 @@ public class SendMessageServlet extends HttpServlet {
 	String displayName = user.getNickname().replaceFirst("@.*", "");
 
 	// Create a message including the user email prefix to display in the chat window
-	String taggedMessage = "<strong>&lt;" + displayName + "&gt;</strong> " + message;
-	Map<String, String> messageData = new HashMap<>();
+	String taggedMessage = "&lt;strong&gt;&amp;lt;" + displayName + "&amp;gt;&lt;/strong&gt; " + message;
+	Map&lt;String, String&gt; messageData = new HashMap<>();
 	messageData.put("message", taggedMessage);
 
 	// Send a message over the Pusher channel (maximum size of a message is 10KB)
@@ -286,8 +286,8 @@ endpoint. For more information about connections, refer to Pusher's
 ```jsp
 // Connect to Pusher with auth endpoint on your server for private/presence channels
 	// (default auth endpoint : /pusher/auth)
-	var pusher = new Pusher('<%= PusherService.APP_KEY %>', {
-		cluster: '<%= PusherService.CLUSTER %>',
+	var pusher = new Pusher('&lt;%= PusherService.APP_KEY %&gt;', {
+		cluster: '&lt;%= PusherService.CLUSTER %&gt;',
 		authEndpoint: '/authorize',
 		encrypted: true
 	});
@@ -329,9 +329,9 @@ The following code snippets show to bind event handlers to Pusher events:
 			// receive list of members on this channel
 			var whosonline_html = '';
 			members.each(function (member) {
-				whosonline_html += '<li class="chat_widget_member" id="chat_widget_member_'
+				whosonline_html += '&lt;li class="chat_widget_member" id="chat_widget_member_'
 					+
-					member.id + '">' + member.info.displayName + '</li>';
+					member.id + '"&gt;' + member.info.displayName + '&lt;/li&gt;';
 			});
 			$('#chat_widget_online_list').html(whosonline_html);
 			updateOnlineCount();
@@ -339,9 +339,9 @@ The following code snippets show to bind event handlers to Pusher events:
 		// presence channel receive events when members are added / removed
 		channel.bind('pusher:member_added', function (member) {
 			// track member additions to channel
-			$('#chat_widget_online_list').append('<li class="chat_widget_member" ' +
-				'id="chat_widget_member_' + member.id + '">'
-				+ member.info.displayName + '</li>');
+			$('#chat_widget_online_list').append('&lt;li class="chat_widget_member" ' +
+				'id="chat_widget_member_' + member.id + '"&gt;'
+				+ member.info.displayName + '&lt;/li&gt;');
 			updateOnlineCount();
 		});
 		channel.bind('pusher:member_removed', function (member) {
@@ -369,9 +369,9 @@ displayed by the chat application.
 			// receive list of members on this channel
 			var whosonline_html = '';
 			members.each(function (member) {
-				whosonline_html += '<li class="chat_widget_member" id="chat_widget_member_'
+				whosonline_html += '&lt;li class="chat_widget_member" id="chat_widget_member_'
 					+
-					member.id + '">' + member.info.displayName + '</li>';
+					member.id + '"&gt;' + member.info.displayName + '&lt;/li&gt;';
 			});
 ```
 

--- a/tutorials/cdn-fastly.md
+++ b/tutorials/cdn-fastly.md
@@ -73,7 +73,7 @@ To create a Cloud Storage bucket:
    click **Create Bucket**.
 1. In the **Create Bucket** dialog, fill out the form as follows:
 
-    +  _Name_: _<your_bucket_name>_ (must be unique)
+    +  _Name_: _&lt;your_bucket_name&gt;_ (must be unique)
     +  _Storage_: Multi-Regional
     +  _Location_: United States
 

--- a/tutorials/cloud-functions-oauth-gmail/index.md
+++ b/tutorials/cloud-functions-oauth-gmail/index.md
@@ -184,7 +184,7 @@ exports.listlabels = (req, res) => {
       // Respond to request
       res.set('Content-Type', 'text/html');
       res.write(`${labels.length} label(s) found:`);
-      labels.forEach(label => res.write(`<br>${label.name}`));
+      labels.forEach(label => res.write(`&lt;br&gt;${label.name}`));
       res.status(200).end();
     })
     .catch((err) => {

--- a/tutorials/cloud-iot-firestore-config/index.md
+++ b/tutorials/cloud-iot-firestore-config/index.md
@@ -89,7 +89,7 @@ const dm = new DeviceManager('config-demo');
 exports.configUpdate = functions.firestore
   // assumes a document whose ID is the same as the deviceid
   .document('device-configs/{deviceId}')
-  .onWrite(async (change: functions.Change<admin.firestore.DocumentSnapshot>, context?: functions.EventContext) => {
+  .onWrite(async (change: functions.Change&lt;admin.firestore.DocumentSnapshot&gt;, context?: functions.EventContext) => {
     if (context) {
       await dm.setAuth();
       console.log(context.params.deviceId);
@@ -211,7 +211,7 @@ const dm = new DeviceManager('config-demo');
 exports.configUpdate = functions.firestore
   // assumes a document whose ID is the same as the deviceid
   .document('device-configs/{deviceId}')
-  .onWrite(async (change: functions.Change<admin.firestore.DocumentSnapshot>, context?: functions.EventContext) => {
+  .onWrite(async (change: functions.Change&lt;admin.firestore.DocumentSnapshot&gt;, context?: functions.EventContext) => {
     if (context) {
       await dm.setAuth();
       console.log(context.params.deviceId);
@@ -228,7 +228,7 @@ exports.configUpdate = functions.firestore
   exports.configUpdateBinary = functions.firestore
   // assumes a document whose ID is the same as the deviceid
   .document('device-configs-binary/{deviceId}')
-  .onWrite(async (change: functions.Change<admin.firestore.DocumentSnapshot>, context?: functions.EventContext) => {
+  .onWrite(async (change: functions.Change&lt;admin.firestore.DocumentSnapshot&gt;, context?: functions.EventContext) => {
     if (context) {
       await dm.setAuth();
       console.log(context.params.deviceId);
@@ -258,7 +258,7 @@ exports.configUpdate = functions.firestore
     exports.configUpdate = functions.firestore
       // assumes a document whose ID is the same as the deviceid
       .document('device-configs/{deviceId}')
-      .onWrite((change: functions.Change<admin.firestore.DocumentSnapshot>, context?: functions.EventContext) => {
+      .onWrite((change: functions.Change&lt;admin.firestore.DocumentSnapshot&gt;, context?: functions.EventContext) => {
         if (context) {
           console.log(context.params.deviceId);
           // get the new config data
@@ -274,7 +274,7 @@ exports.configUpdate = functions.firestore
       exports.configUpdateBinary = functions.firestore
       // assumes a document whose ID is the same as the deviceid
       .document('device-configs-binary/{deviceId}')
-      .onWrite((change: functions.Change<admin.firestore.DocumentSnapshot>, context?: functions.EventContext) => {
+      .onWrite((change: functions.Change&lt;admin.firestore.DocumentSnapshot&gt;, context?: functions.EventContext) => {
         if (context) {
           console.log(context.params.deviceId);
           // get the new config data

--- a/tutorials/cloud-iot-hybrid/index.md
+++ b/tutorials/cloud-iot-hybrid/index.md
@@ -68,7 +68,7 @@ Set the name of the Cloud IoT Core settings you are using to environment variabl
 export CLOUD_REGION=us-central1
 export CLOUD_ZONE=us-central1-c
 export GCLOUD_PROJECT=$(gcloud config list project --format "value(core.project)")
-export IOT_TOPIC=<the Cloud Pub/Sub topic id you have set up with your IoT Core registry this is just short id, not full path)>
+export IOT_TOPIC=&lt;the Cloud Pub/Sub topic id you have set up with your IoT Core registry this is just short id, not full path)&gt;
 ```
 
 While Cloud Shell has the golang runtime pre-installed, we will need a couple other libraries, install them with:

--- a/tutorials/cloud-iot-logging/index.md
+++ b/tutorials/cloud-iot-logging/index.md
@@ -45,8 +45,8 @@ If you do not already have a development environment set up with [gcloud](https:
 Set the name of the Cloud IoT Core settings you are using to environment variables:
 
 ```sh
-export REGISTRY_ID=<your registry here>
-export CLOUD_REGION=<your region; eg us-central1>
+export REGISTRY_ID=&lt;your registry here&gt;
+export CLOUD_REGION=&lt;your region; eg us-central1&gt;
 export GCLOUD_PROJECT=$(gcloud config list project --format "value(core.project)")
 ```
 
@@ -159,7 +159,7 @@ Note: do not use this device for any real workloads, as the keypair is included 
 
 ## Explore the logs that are written
 
-If you open up the <a href="https://console.cloud.google.com/logs/viewer" target="_blank">Stackdriver Logging console</a>.
+If you open up the [Stackdriver Logging console](https://console.cloud.google.com/logs/viewer).
 
 ![console image](https://storage.googleapis.com/gcp-community/tutorials/cloud-iot-logging/c1.png)
 

--- a/tutorials/cloudbuild-angular-universal/index.md
+++ b/tutorials/cloudbuild-angular-universal/index.md
@@ -110,7 +110,7 @@ You will create a repository called `tour-of-heroes-universal`
 
 **Note** that jq is a tool for editing JSON and is installed in Cloud Shell by default. If you are going through this tutorial on your workstation see [jq installation](https://stedolan.github.io/jq/download/) for instructions on installing jq on your workstation.
 
-        read -r -d '' SCRIPT_ADDITIONS <<EOF
+        read -r -d '' SCRIPT_ADDITIONS &lt;&lt;EOF
         {
         "build:prerender": "npm run build:client-and-server-bundles && npm run compile:prerender && npm run generate:prerender",
         "generate:prerender": "npm run webpack:prerender && node dist/prerender.js",
@@ -118,7 +118,7 @@ You will create a repository called `tour-of-heroes-universal`
         "webpack:prerender": "webpack --config webpack.prerender.config.js"
         }
         EOF
-        cat package.json | jq --argjson additions "$SCRIPT_ADDITIONS" '.scripts = .scripts+$additions' >tmpfile
+        cat package.json | jq --argjson additions "$SCRIPT_ADDITIONS" '.scripts = .scripts+$additions' &gt;tmpfile
         cp tmpfile package.json
         rm tmpfile
 
@@ -173,7 +173,7 @@ You will create a repository called `tour-of-heroes-universal`
 
 2.  Create the `cloudbuild.yaml` file.
 
-        cat <<CLOUDBUILD_FILE>cloudbuild.yaml
+        cat &lt;&lt;CLOUDBUILD_FILE&gt;cloudbuild.yaml
         steps:
         - id: install_packages
           name: 'gcr.io/cloud-builders/npm'

--- a/tutorials/developing-services-with-k8s.md
+++ b/tutorials/developing-services-with-k8s.md
@@ -131,8 +131,8 @@ It's time to check out our app in the browser. Let's look up the IP address of o
 % kubectl get services
 NAME           CLUSTER-IP     EXTERNAL-IP      PORT(S)        AGE
 frontend       10.7.252.209   104.196.217.24   80:30563/TCP   2m
-redis-master   10.7.248.117   <none>           6379/TCP       2m
-redis-slave    10.7.245.58    <none>           6379/TCP       2m
+redis-master   10.7.248.117   &lt;none&gt;           6379/TCP       2m
+redis-slave    10.7.245.58    &lt;none&gt;           6379/TCP       2m
 ```
 
 Go to the external IP address of your load balancer (in the above example, 104.196.217.24). You should see the Guestbook application running. Typing into the submit box will show how your message is persisting to the Redis cluster.

--- a/tutorials/envoy-flask-google-container-engine.md
+++ b/tutorials/envoy-flask-google-container-engine.md
@@ -113,7 +113,7 @@ Note that this service is type `ClusterIP`, so that it can be seen only within t
 1. Run `kubectl get services`, which should show its service:
 
         NAME      CLUSTER-IP     EXTERNAL-IP  PORT(S)   AGE
-        postgres  10.107.246.55  <none>       5432/TCP  5s
+        postgres  10.107.246.55  &lt;none&gt;       5432/TCP  5s
 
 At this point the Postgres server is running, reachable from anywhere in the cluster at `postgres:5432`.
 

--- a/tutorials/get-started-bitnami-django.md
+++ b/tutorials/get-started-bitnami-django.md
@@ -106,22 +106,22 @@ Bitnami Django includes a pre-configured instance of the Apache Web server. Conf
 
 1. Add the following Apache directives in the `/opt/bitnami/apps/django/django_projects/myproject/conf/httpd-app.conf` file:
 
-        <IfDefine !IS_DJANGOSTACK_LOADED>
+        &lt;IfDefine !IS_DJANGOSTACK_LOADED&gt;
           Define IS_DJANGOSTACK_LOADED
           WSGIDaemonProcess wsgi-djangostack   processes=2 threads=15    display-name=%{GROUP}
-        </IfDefine>
+        &lt;/IfDefine&gt;
 
-        <Directory "/opt/bitnami/apps/django/django_projects/myproject/myproject">
+        &lt;Directory "/opt/bitnami/apps/django/django_projects/myproject/myproject"&gt;
             Options +MultiViews
             AllowOverride All
-            <IfVersion >= 2.3>
+            &lt;IfVersion >= 2.3&gt;
                 Require all granted
-            </IfVersion>
+            &lt;/IfVersion&gt;
 
             WSGIProcessGroup wsgi-djangostack
 
             WSGIApplicationGroup %{GLOBAL}
-        </Directory>
+        &lt;/Directory&gt;
 
         Alias /myproject/static "/opt/bitnami/apps/django/lib/python3.6/site-packages/Django-2.0.2-py3.6.egg/django/contrib/admin/static"
         WSGIScriptAlias /myproject '/opt/bitnami/apps/django/django_projects/myproject/myproject/wsgi.py'

--- a/tutorials/install-bower-dependencies-on-google-app-engine.md
+++ b/tutorials/install-bower-dependencies-on-google-app-engine.md
@@ -34,7 +34,7 @@ This tutorial discusses three different methods.
 
 1. Then save new dependencies to your bower.json with:
 
-        bower install --save <package-name>
+        bower install --save &lt;package-name&gt;
 
 ## Easiest - Do nothing
 

--- a/tutorials/ios-chatbot-part-2/index.md
+++ b/tutorials/ios-chatbot-part-2/index.md
@@ -79,7 +79,7 @@ In the code snippet above:
 1.  Then, we call the `handleRequest()` to handle the request.
 1.  Once done, don't forget to click the "create" function button. It will deploy the function in the cloud.
 
-There is a subtle difference between <code>[tell()](https://developers.google.com/actions/reference/nodejs/ActionsSdkApp#tell)</code>and <code>[ask()](https://developers.google.com/actions/reference/nodejs/ActionsSdkApp#ask) </code>APIs. <code>tell()</code>will end the conversation and close the mic, while <code>ask()</code> will not. This difference doesn't matter for API.AI projects like the one we demonstrate here in [Part 1](https://cloudplatform.googleblog.com/2017/07/how-to-build-a-conversational-app-that-sees-listens-talks-and-translates-using-Cloud-Machine-Learning-APIs-part-1.html) and Part 2 of this blog post. When we integrate Actions on Google in Part 3, we'll explain this difference in more detail.
+There is a subtle difference between [`tell()`](https://developers.google.com/actions/reference/nodejs/ActionsSdkApp#tell) and [`ask()`](https://developers.google.com/actions/reference/nodejs/ActionsSdkApp#ask) APIs. `tell()` will end the conversation and close the mic, while `ask()` will not. This difference doesn't matter for API.AI projects like the one we demonstrate here in [Part 1](https://cloudplatform.googleblog.com/2017/07/how-to-build-a-conversational-app-that-sees-listens-talks-and-translates-using-Cloud-Machine-Learning-APIs-part-1.html) and Part 2 of this blog post. When we integrate Actions on Google in Part 3, we'll explain this difference in more detail.
 
 As shown below, the **Testing** tab invokes your function, the **General** tab shows statistics, and the **Trigger** tab reveals the HTTP URL created for your function:
 
@@ -125,11 +125,11 @@ You can use the same API key you used for Cloud Speech API.
 
 ## Text to Speech
 
-iOS 7+ has a built-in text-to-speech SDK, <code>[AVSpeechSynthesizer](https://developer.apple.com/reference/avfoundation/avspeechsynthesizer?language=objc)</code>. The code below is all you need to convert text to speech.
+iOS 7+ has a built-in text-to-speech SDK, [`AVSpeechSynthesizer`](https://developer.apple.com/reference/avfoundation/avspeechsynthesizer?language=objc). The code below is all you need to convert text to speech.
 
 
 ```
-#import <AVFoundation/AVFoundation.h>
+#import &lt;AVFoundation/AVFoundation.h&gt;
 AVSpeechUtterance *utterance = [[AVSpeechUtterance alloc] initWithString:message];
 AVSpeechSynthesizer *synthesizer = [[AVSpeechSynthesizer alloc] init];
 [synthesizer speakUtterance:utterance];
@@ -163,7 +163,7 @@ To support additional text-to-speech languages, add this line to the code:
 
 
 ```
-#import <AVFoundation/AVFoundation.h>
+#import &lt;AVFoundation/AVFoundation.h&gt;
 AVSpeechUtterance *utterance = [[AVSpeechUtterance alloc] initWithString:message];
 utterance.voice = [AVSpeechSynthesisVoice voiceWithLanguage:@"zh-Hans"];
 AVSpeechSynthesizer *synthesizer = [[AVSpeechSynthesizer alloc] init];

--- a/tutorials/ios-chatbot-part-3/index.md
+++ b/tutorials/ios-chatbot-part-3/index.md
@@ -48,7 +48,7 @@ Now we'll enable Actions on Google to support the Google Assistant.
 ![alt_text](https://storage.googleapis.com/gcp-community/tutorials/ios-chatbot-part-3/conversational-app-p3-4.png "Actions on Google Intents")
 
 
-If this is your first time on Actions on Google console, it will prompt you to turn on <code>Device Information<em> </em></code>and <em>V<code>oice & Audio Activity</code></em> on your <code>Activity controls</code> center.
+If this is your first time on Actions on Google console, it will prompt you to turn on _Device Information_ and _Voice & Audio Activity_ on your _Activity controls_ center.
 
 
 ![alt_text](https://storage.googleapis.com/gcp-community/tutorials/ios-chatbot-part-3/conversational-app-p3-2.png "Actions on Google Simulator")

--- a/tutorials/iot-device-to-device/README.md
+++ b/tutorials/iot-device-to-device/README.md
@@ -54,7 +54,7 @@ Set it to trigger on the topic configured with your device registry.
     cd virtualdevice
     npm install
     node virtualdev.js --cloudRegion=<region-from-console> \
-        --projectId<your-project-id> \
+        --projectId=<your-project-id> \
         --deviceId=<your-device-id>\
         --privateKeyFile=../rsa_private.pem \
         --algorithm=RS256 \

--- a/tutorials/iot-device-to-device/index.md
+++ b/tutorials/iot-device-to-device/index.md
@@ -112,9 +112,9 @@ After you have generated the keypair, use the public key to register your
 device:
 
     gcloud beta iot devices create \
-        --registry=<your-registry-id> \
+        --registry=&lt;your-registry-id&gt; \
         --region "europe-west1" \
-        --public-key path=rsa_cert.pem,type=rs256 <deviceId>
+        --public-key path=rsa_cert.pem,type=rs256 &lt;deviceId&gt;
 
 Now that you have registered a device, you can connect it using the virtual
 device provided in the sample.
@@ -157,13 +157,13 @@ virtualdevice folder:
 
     cd virtualdevice
     npm install
-    node virtualdev.js --cloudRegion=<region-from-console> \
-        --projectId<your-project-id> \
-        --deviceId=<your-device-id>\
+    node virtualdev.js --cloudRegion=&lt;region-from-console&gt; \
+        --projectId=&lt;your-project-id&gt; \
+        --deviceId=&lt;your-device-id&gt;\
         --privateKeyFile=../rsa_private.pem \
         --algorithm=RS256 \
         --numMessages=1 \
-        --registryId=<your-registry-id>
+        --registryId=&lt;your-registry-id&gt;
 
 When the virtual device connects, it transmits a telemetry message that is
 turned into a Google Cloud PubSub message that reaches the Google Cloud

--- a/tutorials/kubernetes-auth-openid-rbac.md
+++ b/tutorials/kubernetes-auth-openid-rbac.md
@@ -33,7 +33,7 @@ After initializing the master instance, you need to update the `kube api server`
 More information about the OIDC attributes can be found in the [Authenticating](https://kubernetes.io/docs/admin/authentication/#option-1---oidc-authenticator) reference documentation.
 
 
-    sed -i "/- kube-apiserver/a\    - --oidc-issuer-url=https://accounts.google.com\n    - --oidc-username-claim=email\n    - --oidc-client-id=<Your Google Client ID>" /etc/kubernetes/manifests/kube-apiserver.yaml
+    sed -i "/- kube-apiserver/a\    - --oidc-issuer-url=https://accounts.google.com\n    - --oidc-username-claim=email\n    - --oidc-client-id=&lt;Your Google Client ID&gt;" /etc/kubernetes/manifests/kube-apiserver.yaml
 
 
 Add any network CNI plugin and the cluster is ready. Copy `/etc/kubernetes/admin.conf` to local `~/.kube/config` and change the cluster ip.

--- a/tutorials/on-beyond-magpie2.md
+++ b/tutorials/on-beyond-magpie2.md
@@ -89,7 +89,7 @@ This example is concerned with entities though, so it needs to define a class th
 		private String type;
 		  //  Currently type is one of UNKNOWN, PERSON, LOCATION, ORGANIZATION, EVENT, WORK_OF_ART, CONSUMER_GOOD, OTHER
 
-		private Map<String, String> metadata;
+		private Map&lt;String, String&gt; metadata;
 
 		public String getName() {
 			return name;
@@ -99,7 +99,7 @@ This example is concerned with entities though, so it needs to define a class th
 			return type;
 		}
 
-		public Map<String, String> getMetadata() {
+		public Map&lt;String, String&gt; getMetadata() {
 			return metadata;
 		}
 	}
@@ -108,8 +108,8 @@ This example is concerned with entities though, so it needs to define a class th
 Additional information returned about an entity (such as mentions and salience) are not included since this example does not need them. Once the classes that represent the results you want are defined, you can create a `Gson` object and use it to parse the string you have created as shown below. In this example, it will just return a list of the entities in the user input.
 
 
-	private List<String> getEntities (String jsonString) {
-		List<String> result = new ArrayList<String>();
+	private List&lt;String&gt; getEntities (String jsonString) {
+		List&lt;String&gt; result = new ArrayList&lt;String&gt;();
 		Gson gson = new GsonBuilder().create();
 
 		AnalyzeEntitiesResponse json = (AnalyzeEntitiesResponse)gson.fromJson(jsonString, AnalyzeEntitiesResponse.class);
@@ -126,7 +126,7 @@ Additional information returned about an entity (such as mentions and salience) 
 At this point, you can call this method and use the results to have your chatbot respond to the entities in user statements. A simple response would be to react to the first entity it finds.
 
 
-	List<String> entities = getEntities(results);
+	List&lt;String&gt; entities = getEntities(results);
 
 	if (entities.size() > 0) {
 		// Pick the first entity and ask about it

--- a/tutorials/puppet-in-google-cloud-platform.md
+++ b/tutorials/puppet-in-google-cloud-platform.md
@@ -88,15 +88,17 @@ You can also do a single sign by
         sudo mkdir -p webserver/manifests
 
 3. In the new manifests directory, create a file named init.pp, and copy the following code into it:
+
         class webserver {
           package { 'apache2':
           ensure => present
         }
         file {'/var/www/html/index.html': # resource type file and filename
           ensure => present, # make sure it exists
-          content => "<h1>This page is installed from Puppet Master</h1>", # content of the file
+          content => "&lt;h1&gt;This page is installed from Puppet Master&lt;/h1&gt;", # content of the file
         }
       }
+
 4. Run the following command on the puppet-agent instance to get the catalog from the Puppet master and apply the manifest:
 
         sudo /opt/puppetlabs/bin/puppet agent --test

--- a/tutorials/run-botkit-on-google-container-engine/index.md
+++ b/tutorials/run-botkit-on-google-container-engine/index.md
@@ -339,7 +339,7 @@ You can follow these steps to clean up resources and save on costs.
 
         Command output
 
-            gs://artifacts.<PROJECT_ID>.appspot.com/
+            gs://artifacts.&lt;PROJECT_ID&gt;.appspot.com/
 
     2.  Delete the bucket and all the images it contains.
 

--- a/tutorials/setting-up-lemp.md
+++ b/tutorials/setting-up-lemp.md
@@ -135,11 +135,11 @@ look up the address in the
 
     * Debian 7
 
-            sudo sh -c 'echo "<?php phpinfo();?>" > /usr/share/nginx/www/phpinfo.php'
+            sudo sh -c 'echo "&lt;?php phpinfo();?&gt;" > /usr/share/nginx/www/phpinfo.php'
 
     * Ubuntu 14.04 or CentOS 6
 
-            sudo sh -c 'echo "<?php phpinfo();?>" > /usr/share/nginx/html/phpinfo.php'
+            sudo sh -c 'echo "&lt;?php phpinfo();?&gt;" > /usr/share/nginx/html/phpinfo.php'
 
 1. Browse to the test file to verify that `nginx` and PHP are working together:
 

--- a/tutorials/setting-up-postgres-hot-standby.md
+++ b/tutorials/setting-up-postgres-hot-standby.md
@@ -170,9 +170,8 @@ create the new user.
 configuration files.
 
 * `-P` prompts you for the new user's password.
-  <aside class="caution"><strong>Important</strong>:
-     For any system with an Internet connection, use a
-     strong password to help keep the system secure.</aside>
+    **Important**: For any system with an Internet connection, use a
+    strong password to help keep the system secure.
 
 * `-c` sets a limit for the number of connections for the new user. The value
 `5` is sufficient for replication purposes.
@@ -204,10 +203,10 @@ must add an entry for the user `repuser` to enable replication.
         $ nano ../../etc/postgresql/9.3/main/pg_hba.conf
 
 1. After the example replication entries, add the following lines. Replace
-`<standby-IP>` with the external IP address of the standby server:
+`&lt;standby-IP&gt;` with the external IP address of the standby server:
 
         # Allow replication connections
-        host     replication     repuser         <standby-IP>/32        md5
+        host     replication     repuser         &lt;standby-IP&gt;/32        md5
 
 1. Save and close the file.
 
@@ -287,10 +286,10 @@ data directory on the standby server. Run the following command:
 
         $ mv ../../var/lib/postgresql/9.3/main ../../var/lib/postgresql/9.3/main_old
 
-1. Run the backup utility. Replace `<primary-IP>` with the external IP address
+1. Run the backup utility. Replace `&lt;primary-IP&gt;` with the external IP address
 of the primary server.
 
-        $ sudo -u postgres pg_basebackup -h <primary IP> -D /var/lib/postgresql/9.3/main -U repuser -v -P --xlog-method=stream
+        $ sudo -u postgres pg_basebackup -h &lt;primary IP&gt; -D /var/lib/postgresql/9.3/main -U repuser -v -P --xlog-method=stream
 
     The backup utility will prompt you for the password for the user named
     `repuser`.
@@ -343,10 +342,10 @@ standby server, enter the following command:
         standby_mode = on
 
 1. Set the connection string to the primary server. Replace
-`<primary-external-IP>` with the external IP address of the primary server.
-Replace `<password>` with  the password for the user named `repuser`.
+    `&lt;primary-external-IP&gt;` with the external IP address of the primary server.
+    Replace `&lt;password&gt;` with  the password for the user named `repuser`.
 
-        primary_conninfo = 'host=<primary-external-IP> port=5432 user=repuser password=<password>'
+        primary_conninfo = 'host=&lt;primary-external-IP&gt; port=5432 user=repuser password=&lt;password&gt;'
 
 1. (Optional) Set the trigger file location:
 
@@ -438,9 +437,9 @@ restart the server.
         $ mv ../../var/lib/postgresql/9.3/main ../../var/lib/postgresql/9.3/main_old_2
 
 1. On the standby server, run `pgbasebackup` again to synchronize the data.
-Substitute `<primary-IP>` with your primary server's external IP address:
+Substitute `&lt;primary-IP&gt;` with your primary server's external IP address:
 
-        $ sudo -u postgres pg_basebackup -h <primary-IP> -D /var/lib/postgresql/9.3/main -U repuser -v -P --xlog-method=stream
+        $ sudo -u postgres pg_basebackup -h &lt;primary-IP&gt; -D /var/lib/postgresql/9.3/main -U repuser -v -P --xlog-method=stream
 
 1. The `main` folder now needs a copy of `recovery.conf`. You can simply copy it
 from the folder that you renamed to `main_old_2`:

--- a/tutorials/setting-up-ruby-discourse.md
+++ b/tutorials/setting-up-ruby-discourse.md
@@ -52,7 +52,7 @@ database your Discourse app will use.
 
 1. In the Cloud Shell terminal that appears, run:
 
-        gcloud beta sql connect <The Cloud SQL instance name> --user=discourse
+        gcloud beta sql connect &lt;The Cloud SQL instance name&gt; --user=discourse
 
 1. When prompted, type in the password `discourse`.
 
@@ -77,10 +77,10 @@ We'll configure the Discourse app to run on the App Engine flexible environment 
         db_password = discourse
 
         # socket name for database connection
-        db_host = /cloudsql/<Cloud SQL instance connection name>
+        db_host = /cloudsql/&lt;Cloud SQL instance connection name&gt;
 
         # Redis host address
-        redis_host = <Redis instance internal IPv4 address>
+        redis_host = &lt;Redis instance internal IPv4 address&gt;
 
         # enable serve_static_assets for dockerized app
         serve_static_assets = true
@@ -113,7 +113,7 @@ We'll configure the Discourse app to run on the App Engine flexible environment 
         env: flex
         entrypoint: bundle exec rails s -p 8080
         beta_settings:
-          cloud_sql_instances: <Cloud SQL Instance connection name>
+          cloud_sql_instances: &lt;Cloud SQL Instance connection name&gt;
 
 1. In the same application root directory, run this gcloud SDK command to deploy:
 

--- a/tutorials/ssh-port-forwarding-set-up-load-testing-on-compute-engine/index.md
+++ b/tutorials/ssh-port-forwarding-set-up-load-testing-on-compute-engine/index.md
@@ -103,11 +103,11 @@ Note that “A” and “B” in Figure 6 refer to port numbers.
 
 To set up server side SSH port forwarding as shown in the examples above, you would execute the following command on your client machine (-L indicates local and -R indicates remote).
 
-`ssh -L A:127.0.0.1:B <username>@<server>`
+`ssh -L A:127.0.0.1:B &lt;username&gt;@&lt;server&gt;`
 
 Similarly, the following command sets up the client side port forwarding.
 
-`ssh -R  B:127.0.0.1:A <username>@<server>`
+`ssh -R  B:127.0.0.1:A &lt;username&gt;@&lt;server&gt;`
 
 On Windows, you can configure SSH port forwarding by using [PuTTY](http://www.putty.org/) from “Connection” - “SSH” - “Tunnels” of PuTTY configuration in a similar manner.
 
@@ -127,7 +127,7 @@ The example command below sets up forwarding for 3 ports. You might want to add 
 ```
 ssh -L 24000:127.0.0.1:24000   \
 -R 25000:127.0.0.1:25000   \
--L 26000:127.0.0.1:26000 -N -f <username>@<server>
+-L 26000:127.0.0.1:26000 -N -f &lt;username&gt;@&lt;server&gt;
 ```
 
 To use the proper port numbers, all that is left to do is to configure the JMeter client and server.
@@ -187,7 +187,7 @@ With the `gcloud compute ssh` command you need to specify the `--` option to pas
 To set up the SSH port forwarding for Compute Engine, use the following command:
 
 ```
-gcloud compute ssh <instance name> --zone <zone> -- -L 24000:127.0.0.1:24000  \
+gcloud compute ssh &lt;instance name&gt; --zone &lt;zone&gt; -- -L 24000:127.0.0.1:24000  \
 -R 25000:127.0.0.1:25000 \
 -L 26000:127.0.0.1:26000  -N -f
 ```
@@ -205,7 +205,7 @@ All servers can still use the same number for the RMI port to connect to the cli
 Suppose the second JMeter server uses 24001 and 26001 for the JMeter connection and the RMI from client to server respectively. In this case, the SSH port forward setup command for the second server should be:
 
 ```
-gcloud compute ssh <instance name> --zone <zone> -- -L 24001:127.0.0.1:24001  \
+gcloud compute ssh &lt;instance name&gt; --zone &lt;zone&gt; -- -L 24001:127.0.0.1:24001  \
 -R 25000:127.0.0.1:25000  \
 -L 26001:127.0.0.1:26001 -N -f
 ```
@@ -268,7 +268,7 @@ Here’s of an overview of what the script does:
 
 **Start a cluster and set SSH port forwarding**
 
-`./jmeter_cluster.py start [cluster size] [--project <project name>] [--prefix <prefix>] [--image <image>] [--zone <zone>] [--machinetype <machine type>]`
+`./jmeter_cluster.py start [cluster size] [--project &lt;project name&gt;] [--prefix &lt;prefix&gt;] [--image &lt;image&gt;] [--zone &lt;zone&gt;] [--machinetype &lt;machine type&gt;]`
 
 - Starts up a cluster that consists of \[cluster size\] number of Compute Engine instances.
 - Also sets SSH port forwarding.
@@ -277,7 +277,7 @@ After running the start command to start the JMeter server, run the client comma
 
 **Set SSH port forwarding if the terminal is interrupted** 
 
-`./jmeter_cluster.py portforward [cluster size] [--project <project name>] [--prefix <prefix>]`
+`./jmeter_cluster.py portforward [cluster size] [--project &lt;project name&gt;] [--prefix &lt;prefix&gt;]`
 
 - Sets SSH port forwarding for \[cluster size\] number of instances.
 - This is required only when the terminal that started the cluster loses connection to the instances which, in turn, cancels SSH port forwarding.
@@ -292,7 +292,7 @@ After running the portforward command to re-establish port forwarding, run the c
 
 **Shutdown the JMeter System** 
 
-`./jmeter_cluster.py shutdown [--project <project name>] [--prefix <prefix>]`
+`./jmeter_cluster.py shutdown [--project &lt;project name&gt;] [--prefix &lt;prefix&gt;]`
 
 - Tears down the JMeter server cluster.
 

--- a/tutorials/ssh-tunnel-on-gce.md
+++ b/tutorials/ssh-tunnel-on-gce.md
@@ -119,7 +119,7 @@ $ curl --proxy socks5://localhost:5000 https://api.ip2geo.pl/json/
 ### Clean up
 
 Once you are done using the SSH proxy, you can terminate `gcloud compute ssh`
-command with <kbd>Ctrl</kbd>+<kbd>C</kbd>.
+command with `Ctrl`+`C`.
 
 If you are no longer planning to use the instance serving the proxy, you can
 delete the instance using the following command to prevent unwanted charges to

--- a/tutorials/styleguide.md
+++ b/tutorials/styleguide.md
@@ -285,7 +285,9 @@ stripped out as raw HTML.
 
 ### Disallowed Raw HTML
 
-Publishing strips *all* possible HTML from tutorial content, essentially anything contained within `<` and `>` delimiters. Note that this is stricter than standard GFM, which only strips certain "unsafe" HTML.
+Publishing strips *all* possible HTML from tutorial content, essentially anything contained within `<` and `>` delimiters. Note that this is stricter than standard GFM, which only strips certain "unsafe" HTML. This _includes_ such content in preformatted or code blocks, so be extra careful with HTML, templated type specifications, and similar constructs in code snippets.
+
+If you do need to include literal `<` or `>` characters, use the corresponding HTML entities `&amp;lt;` and `&amp;gt;`. Similarly, if your content includes a literal HTML entity, you must escape the ampersand, as in `&amp;amp;lt;`.
 
 ### Strikethrough
 

--- a/tutorials/using-cloud-vpn-with-alibaba-site-to-site/index.md
+++ b/tutorials/using-cloud-vpn-with-alibaba-site-to-site/index.md
@@ -178,10 +178,10 @@ Use these settings for the procedures in the subsections that follow.
 Below are fields you might be asked to complete for the Alibaba Cloud side configurations. 
 The defaults indicated below will work with the defaults used on the GCP side.
 
-+  **Encryption algorithm**—<code>aes</code> 
-+  **Integrity algorithm**—<code>sha1</code> 
-+  **Diffie-Hellman group**—<code>group2</code>
-+  **Lifetime/SA life cycles**—<code>86400</code> seconds
++  **Encryption algorithm** — `aes`
++  **Integrity algorithm** — `sha1`
++  **Diffie-Hellman group** — `group2`
++  **Lifetime/SA life cycles** — `86400` seconds
 
 ## Configuration overview
 

--- a/tutorials/using-cloud-vpn-with-cisco-asr/index.md
+++ b/tutorials/using-cloud-vpn-with-cisco-asr/index.md
@@ -808,7 +808,7 @@ it can support up to 16 equal cost paths load balancing.
      bgp log-neighbor-changes
      neighbor GCP peer-group
      neighbor GCP remote-as 65002
-     neighbor GCP timers <b>20 60 60
+     neighbor GCP timers 20 60 60
      neighbor 169.254.0.1 peer-group GCP
      neighbor 169.254.0.9 peer-group GCP
     !

--- a/tutorials/wix-media-python.md
+++ b/tutorials/wix-media-python.md
@@ -49,7 +49,7 @@ server, and running the sample:
 
 1. Start the local App Engine development server:
 
-        <path_to_appengine_sdk>/dev_appserver.py examples/gae
+        &lt;path_to_appengine_sdk&gt;/dev_appserver.py examples/gae
 
 1. Launch [http://localhost:8080](http://localhost:8080)
    to view the sample app. The sample demonstrates creating thumbnails using the Wix Media Python SDK.


### PR DESCRIPTION
I grepped through all the markdown files and did something with all the syntax that the publisher is removing because it thinks it is an HTML tag. In some cases, these are actual HTML tags that were extraneous or needed to be transformed into equivalent markdown syntax. In other cases, they should be literal angle brackets (e.g. in code snippets) and so were replaced with the equivalent html entities `&lt;` and `&gt;`. I checked each such replacement to verify that it corresponded to actual "missing" content in the currently rendered tutorials. (However I am not able to verify the rendered results.)

This PR may actually fix a number of existing reported issues. (For example, a number of the code snippets will simply not work as rendered because they are missing content.) I'll go through the list and see what I can find.

/cc @ToddKopriva 