### PR TITLE
Updated code to be compatible with 3.0 version of MongoDB driver

### DIFF
--- a/tutorials/nodejs-mongodb-on-appengine.md
+++ b/tutorials/nodejs-mongodb-on-appengine.md
@@ -67,10 +67,12 @@ There are multiple options for creating a new MongoDB database. For example:
         }
         console.log(uri);
 
-        mongodb.MongoClient.connect(uri, (err, db) => {
+        mongodb.MongoClient.connect(uri, { useNewUrlParser: true }, (err, client) => {
           if (err) {
             throw err;
           }
+        
+         const db = client.db(nconf.get("mongoDatabase"))
 
           // Create a simple little server.
           http.createServer((req, res) => {
@@ -89,7 +91,7 @@ There are multiple options for creating a new MongoDB database. For example:
               address: req.connection.remoteAddress
             };
 
-            collection.insert(ip, (err) => {
+            collection.insertOne(ip, (err) => {
               if (err) {
                 throw err;
               }


### PR DESCRIPTION
For issue #449. Existing code results in an error with more recent versions of the MongoDB driver. Added `{ useNewUrlParser: true }` to `MongoClient.connect()`. Changed `collection.insert()` to `collection.insertOne()` as the prior was deprecated. Updated `MongoClient.connect()` to return a client object rather than a db object.