### PR TITLE
Update service account name and key

### DIFF
--- a/tutorials/zero-to-lamp-deploy-with-chef/index.md
+++ b/tutorials/zero-to-lamp-deploy-with-chef/index.md
@@ -339,7 +339,7 @@ Configure your web server machine for ssh access from the Chef Workstation.
 1.  Authenticate the Chef Workstation machine to use Compute Engine commands.
 
         # gce: chef-workstation
-        gcloud auth activate-service-account compute@$PROJECT_NAME.iam.gserviceaccount.com --key-file=compute.json
+        gcloud auth activate-service-account chef-workstation@$PROJECT_NAME.iam.gserviceaccount.com --key-file=key.json
 
 1.  Connect to the `web-server`. This will force the creation of a new SSH key and upload it to the Compute Engine instance.
 


### PR DESCRIPTION
Update service account name and key for the activate service account command on the chef-workstation instance. Name and key need to match the key that was created earlier