### PR TITLE
Update index.md

### DIFF
--- a/tutorials/https-load-balancing-nginx/index.md
+++ b/tutorials/https-load-balancing-nginx/index.md
@@ -182,7 +182,7 @@ copying the files to the instances as follows:
 ```sh
 for i in {1..3};
   do \
-    gcloud compute copy-files /local/path/to/ssl-certs \
+    gcloud compute scp /local/path/to/ssl-certs \
       root@www-$i:/etc/apache2; \
   done
 ```


### PR DESCRIPTION
`gcloud compute copy-files` is deprecated.  Please use `gcloud compute scp` instead.