### PR TITLE
using square brackets instead of angle brackets

### DIFF
--- a/tutorials/cloud-iot-hybrid/index.md
+++ b/tutorials/cloud-iot-hybrid/index.md
@@ -1,6 +1,6 @@
 ---
-title: Using IoT Core as Scalable Ingest for Hybrid Projects
-description: Use the scale and security of Google Cloud for ingest with on prem IoT applications.
+title: Using IoT Core as scalable ingest for hybrid projects
+description: Use the scale and security of Google Cloud Platform for ingest with on-premises IoT applications.
 author: ptone
 tags: Cloud IoT Core, Hybrid, Networking
 date_published: 2018-05-30
@@ -8,13 +8,13 @@ date_published: 2018-05-30
 
 Preston Holmes | Solution Architect | Google
 
-This tutorial demonstrates how to use [Cloud IoT Core](https://cloud.google.com/iot) and [Cloud Pub/Sub](https://cloud.google.com/pubsub/) to provide a secure and scalable ingest layer, combined with a small relay service over private networking to an on-prem IoT solution.
+This tutorial demonstrates how to use [Cloud IoT Core](https://cloud.google.com/iot) and [Cloud Pub/Sub](https://cloud.google.com/pubsub/) to provide a secure and scalable ingest layer, combined with a small relay service over private networking to an on-premises IoT solution.
 
 ## Objectives
 
-- Configure IoT Core and Pubsub as a fully managed ingest system
-- Configure a stand-in for on-prem MQTT service on Compute Engine
-- Create a small, scalable relay service that pulls messages from Cloud Pubsub
+- Configure IoT Core and Cloud Pub/Sub as a fully managed ingest system
+- Configure a stand-in for on-premises MQTT service on Compute Engine
+- Create a small, scalable relay service that pulls messages from Cloud Pub/Sub
 
 **Figure 1.** *Architecture diagram for tutorial components*
 ![architecture diagram](https://storage.googleapis.com/gcp-community/tutorials/cloud-iot-hybrid/architecture.png)
@@ -42,21 +42,21 @@ The idea of using fully managed scaling services is common for developers lookin
 **Figure 2.** *CDN pattern*
 ![architecture diagram](https://storage.googleapis.com/gcp-community/tutorials/cloud-iot-hybrid/CDN.png)
 
-Many IoT related projects begin with a simple MQTT broker created inside premises (on-prem) corporate infrastructure to simplify installation while still allowing internal access. Internal apps use data arriving on this broker, along with access to other on-prem systems to build business facing IoT applications. There are many reasons why a company may prefer to pursue hybrid development. For example, hybrid development may make it easier to assess or control costs, can control data access, and so on.
+Many IoT related projects begin with a simple MQTT broker created inside premises (on-prem) corporate infrastructure to simplify installation while still allowing internal access. Internal apps use data arriving on this broker, along with access to other on-premises systems to build business-facing IoT applications. There are many reasons why a company may prefer to pursue hybrid development. For example, hybrid development may make it easier to assess or control costs, can control data access, and so on.
 
-Taking this initial MQTT broker and exposing it externally to production scales of device traffic may pose many challenges to a strictly on-prem development, including:
+Taking this initial MQTT broker and exposing it externally to production scales of device traffic may pose many challenges to a strictly on-premises development, including:
 
  - Increasing reliability of the network available to devices.
  - Allowing many devices to connect concurrently (MQTT is a stateful connection).
  - Keeping the MQTT broker up and running reliably.
- - Keeping the connection between devices and the cloud secure, while not exposing other on-prem network services.
+ - Keeping the connection between devices and the cloud secure, while not exposing other on-premises network services.
 
  These requirements resemble that of a CDN, but in reverse.
 
 **Figure 3.** *Global Ingest*
 ![architecture diagram](https://storage.googleapis.com/gcp-community/tutorials/cloud-iot-hybrid/ingest-relay.png) 
 
-Let's quickly setup up an implementation of a solution that uses Google's fully managed services and scale it to address some of these concerns while allowing the primary application to still be developed on-prem.
+Let's quickly set up up an implementation of a solution that uses Google's fully managed services and scale it to address some of these concerns while allowing the primary application to still be developed on-premises.
 
 ## Set up the environment
 
@@ -68,27 +68,27 @@ Set the name of the Cloud IoT Core settings you are using to environment variabl
 export CLOUD_REGION=us-central1
 export CLOUD_ZONE=us-central1-c
 export GCLOUD_PROJECT=$(gcloud config list project --format "value(core.project)")
-export IOT_TOPIC=<the Cloud Pub/Sub topic id you have set up with your IoT Core registry this is just short id, not full path)>
+export IOT_TOPIC=[the Cloud Pub/Sub topic ID you have set up with your IoT Core registry; this is just short ID, not full path]
 ```
 
-While Cloud Shell has the golang runtime pre-installed, we will need a couple other libraries, install them with:
+While Cloud Shell has the golang runtime pre-installed, we will need a couple other libraries. Install them with this command:
 
 ```sh
 go get cloud.google.com/go/pubsub cloud.google.com/go/compute/metadata github.com/eclipse/paho.mqtt.golang
 ```
 
-Finally clone the repo associated with the community tutorials:
+Finally clone the repository associated with the community tutorials:
 
 ```sh
 git clone https://github.com/GoogleCloudPlatform/community.git
 ```
 
-## Create the "on-prem" broker
+## Create the on-premises broker
 
 You will use the project private networking as a stand-in for a proper hybrid [Google Cloud Interconnect](https://cloud.google.com/interconnect/) setup.
 
 
-Start by creating a VM to represent the on prem broker instance. This will be running a basic version of [RabbitMQ](https://www.rabbitmq.com/).
+Start by creating a VM to represent the on-premises broker instance. This will be running a basic version of [RabbitMQ](https://www.rabbitmq.com/).
 
 ```sh
 gcloud beta compute instances create-with-container on-prem-rabbit \
@@ -114,7 +114,7 @@ gcloud compute firewall-rules create mqtt --direction=INGRESS --priority=1000 --
 
 ## Set up the relay
 
-In order for the relay to receive message from IoT Core and Pub/Sub, it will need a dedicated subscription:
+In order for the relay to receive message from IoT Core and Cloud Pub/Sub, it will need a dedicated subscription:
 
 ```sh
 gcloud pubsub subscriptions create relay --topic $IOT_TOPIC
@@ -194,7 +194,7 @@ func main() {
 }
 ```
 
-The goal of the relay is to efficiently pull messages from Cloud Pub/Sub, and then re-publish to the on-prem MQTT broker. It takes advantage of [asynchronous pull](https://cloud.google.com/pubsub/docs/pull#asynchronous-pull) of Cloud Pubsub (sometimes called streaming pull) which uses [streaming gRPC](https://grpc.io/docs/guides/concepts.html#server-streaming-rpc) messages to reduce latency and increase throughput.
+The goal of the relay is to efficiently pull messages from Cloud Pub/Sub, and then re-publish to the on-prem MQTT broker. It takes advantage of [asynchronous pull](https://cloud.google.com/pubsub/docs/pull#asynchronous-pull) of Cloud Pub/Sub (sometimes called streaming pull) which uses [streaming gRPC](https://grpc.io/docs/guides/concepts.html#server-streaming-rpc) messages to reduce latency and increase throughput.
 
 Create a VM to run as the relay:
 
@@ -217,7 +217,7 @@ This script will build the binary, install it on the relay VM, and start it as a
 
 ## Verifying traffic flow
 
-You can now use an MQTT client to connect to the stand-in for the on-prem broker. This would represent some part of the on-prem IoT application. One simple browser based tool you can use in Chrome is [MQTTLens](https://chrome.google.com/webstore/detail/mqttlens/hemojaaeigabkbcookmlgmdigohjobjm?hl=en).
+You can now use an MQTT client to connect to the stand-in for the on-premises broker. This would represent some part of the on-premises IoT application. One simple browser-based tool you can use in Chrome is [MQTTLens](https://chrome.google.com/webstore/detail/mqttlens/hemojaaeigabkbcookmlgmdigohjobjm?hl=en).
 
 Use the public IP address of the `on-prem-rabbit` instance, along with a username of `user` and password of `abc123` to connect.
 
@@ -233,16 +233,16 @@ You can also quickly emulate this by publishing directly to the Cloud Pub/Sub to
 gcloud pubsub topics publish $IOT_TOPIC --attribute=subFolder=sample --message "hello"
 ```
 
-The relay republishes this to the corresponding MQTT topic on the on-prem broker over the private network, in this case using the project-level private network DNS to lookup `on-prem-rabbit` host. (refer to the architecture figure above for a refresher of the data flow)
+The relay republishes this to the corresponding MQTT topic on the on-premises broker over the private network, in this case using the project-level private network DNS to lookup `on-prem-rabbit` host. (Refer to the architecture figure above for a refresher of the data flow.)
 
 ## Next steps
 
 This relay service could be adapted in a number of ways:
 
-- Scaled out to consume more messages in parallel from PubSub - perhaps deployed to [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/).
-- Use rate limiting to protect the on-prem broker from overload, using the PubSub subscription as a "surge tank".
+- Scaled out to consume more messages in parallel from Cloud Pub/Sub - perhaps deployed to [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/).
+- Use rate limiting to protect the on-premises broker from overload, using the Cloud Pub/Sub subscription as a "surge tank".
 
-You might also consider having the relay pulling from Pubsub and writing more directly to alternate services on-prem, instead of through an on-prem MQTT broker. However by relaying MQTT, it lets the on-prem development proceed if MQTT was already built into the solution, or if a looser coupling is wanted.
+You might also consider having the relay pulling from Cloud Pub/Sub and writing more directly to alternate services on-premises, instead of through an on-premises MQTT broker. However, by relaying MQTT, it lets the on-premises development proceed if MQTT was already built into the solution, or if a looser coupling is wanted.
 
 
 ## Cleaning up


### PR DESCRIPTION
Because the HTML sanitizer strips the angle brackets and their contents, I switched the placeholder in a codeblock to use square brackets.

Since I was in the file anyway, I fixed some of the bigger branding and style issues.