### PR TITLE
escaping angle brackets

### DIFF
--- a/tutorials/developing-services-with-k8s.md
+++ b/tutorials/developing-services-with-k8s.md
@@ -1,6 +1,6 @@
 ---
 title: Locally developing microservices with Google Kubernetes Engine
-description: Learn how to set up a dev environment that lets you code/test changes locally, while connecting to other services running in Google Kubernetes Engine.
+description: Learn how to set up a development environment that lets you code and test changes locally, while connecting to other services running in Google Kubernetes Engine.
 author: richarddli
 tags: microservices, Kubernetes Engine, telepresence, PHP, Redis
 date_published: 2017-04-05
@@ -19,10 +19,10 @@ The [guestbook](https://cloud.google.com/kubernetes-engine/docs/tutorials/guestb
 
 ## Prerequisites and setup
 
-In order to use this demo, you're going to need:
+In order to use this demo, you're going to need the following:
 
 * A local system running either Linux or Mac OS X
-* Access to a Kubernetes cluster (this tutorial will walk through setting up a cluster using Google Kubernetes Engine)
+* Access to a Kubernetes cluster (This tutorial will walk through setting up a cluster using Google Kubernetes Engine.)
 
 ## Microservices
 
@@ -88,7 +88,7 @@ Setting up a production-ready Kubernetes cluster can be fairly complex, so we're
 
 To set up a Kubernetes cluster in Kubernetes Engine, go to [https://console.cloud.google.com](https://console.cloud.google.com), choose the Google Kubernetes Engine option from the menu, and then Create a Cluster.
 
-The following gcloud command will create a small 2 node cluster in the us-central1-a region:
+The following `gcloud` command will create a small 2 node cluster in the us-central1-a region:
 
 ```
 % gcloud container --project "PROJECT" clusters create "EXAMPLE_NAME" --zone "us-central1-a" --machine-type "n1-standard-1" --image-type "GCI" --disk-size "100" --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "2" --network "default" --enable-cloud-logging --enable-cloud-monitoring
@@ -131,8 +131,8 @@ It's time to check out our app in the browser. Let's look up the IP address of o
 % kubectl get services
 NAME           CLUSTER-IP     EXTERNAL-IP      PORT(S)        AGE
 frontend       10.7.252.209   104.196.217.24   80:30563/TCP   2m
-redis-master   10.7.248.117   <none>           6379/TCP       2m
-redis-slave    10.7.245.58    <none>           6379/TCP       2m
+redis-master   10.7.248.117   &lt;none&gt;           6379/TCP       2m
+redis-slave    10.7.245.58    &lt;none&gt;           6379/TCP       2m
 ```
 
 Go to the external IP address of your load balancer (in the above example, 104.196.217.24). You should see the Guestbook application running. Typing into the submit box will show how your message is persisting to the Redis cluster.
@@ -171,7 +171,7 @@ Terminate the PHP process, and type `exit` to terminate the Telepresence proxy a
 
 What's going on behind the scenes? Your incoming request goes to the load balancer. The load balancer, as mentioned above, looks for the Telepresence proxy based on the `app:guestbook` and `tier:frontend` labels. The proxy, which is running in the cloud Kubernetes environment, then sends those requests to the local Telepresence client, which passes the request to the PHP application.
 
-## Additional Resources
+## Additional resources
 
 * [Setting up a Python development environment for Docker](http://matthewminer.com/2015/01/25/docker-dev-environment-for-web-app.html) covers how to configure your Docker image for hot reload
 * [Doing the same for NodeJS](http://fostertheweb.com/2016/02/nodemon-inside-docker-container/)

--- a/tutorials/developing-services-with-k8s.md
+++ b/tutorials/developing-services-with-k8s.md
@@ -21,7 +21,7 @@ The [guestbook](https://cloud.google.com/kubernetes-engine/docs/tutorials/guestb
 
 In order to use this demo, you're going to need the following:
 
-* A local system running either Linux or Mac OS X
+* A local system running either Linux or macOS
 * Access to a Kubernetes cluster (This tutorial will walk through setting up a cluster using Google Kubernetes Engine.)
 
 ## Microservices
@@ -169,7 +169,7 @@ Terminate the PHP process, and type `exit` to terminate the Telepresence proxy a
 
 ### Behind the scenes
 
-What's going on behind the scenes? Your incoming request goes to the load balancer. The load balancer, as mentioned above, looks for the Telepresence proxy based on the `app:guestbook` and `tier:frontend` labels. The proxy, which is running in the cloud Kubernetes environment, then sends those requests to the local Telepresence client, which passes the request to the PHP application.
+What's going on behind the scenes? Your incoming request goes to the load balancer. The load balancer, as mentioned above, looks for the Telepresence proxy based on the `app:guestbook` and `tier:frontend` labels. The proxy, which is running in the Google Kubernetes Engine environment, then sends those requests to the local Telepresence client, which passes the request to the PHP application.
 
 ## Additional resources
 


### PR DESCRIPTION
Because our HTML sanitizer strips angle brackets and the contents between them, I escaped a couple of sets of them.

While I was in the file, I fixed a few copy-editing issues.