### PR TITLE
fix: Remove read-only /rootfs from docker command

### DIFF
--- a/tutorials/docker-compose-on-container-optimized-os.md
+++ b/tutorials/docker-compose-on-container-optimized-os.md
@@ -74,7 +74,7 @@ image](https://hub.docker.com/r/docker/compose/).
 
         docker run docker/compose:1.24.0 version
 
-1.  Ensure your location is a writable directory.
+1.  Ensure that your location is a writable directory.
 
     Many directories are [mounted as read-only in the Container-Optimized
     OS](/container-optimized-os/docs/concepts/disks-and-filesystem). Change

--- a/tutorials/docker-compose-on-container-optimized-os.md
+++ b/tutorials/docker-compose-on-container-optimized-os.md
@@ -97,7 +97,7 @@ image](https://hub.docker.com/r/docker/compose/).
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD:$PWD" \
             -w="$PWD" \
-            docker/compose:1.13.0 up
+            docker/compose:1.24.0 up
 
 1.  With the `docker run` command still running, open the [Google Cloud
     Platform Console instances
@@ -111,7 +111,7 @@ image](https://hub.docker.com/r/docker/compose/).
 
 ## Making an alias to Docker Compose
 
-The `docker run ... docker/compose:1.13.0 up` command is equivalent to running
+The `docker run ... docker/compose:1.24.0 up` command is equivalent to running
 the `docker-compose up` command on systems where Docker Compose is installed by
 the usual method. So that you don't have to remember or type this long command,
 create an alias for it.
@@ -123,7 +123,7 @@ create an alias for it.
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD:$PWD" \
             -w="$PWD" \
-            docker/compose:1.13.0'"'" >> ~/.bashrc
+            docker/compose:1.24.0'"'" >> ~/.bashrc
 
 1.  Reload the Bash configuration.
 

--- a/tutorials/docker-compose-on-container-optimized-os.md
+++ b/tutorials/docker-compose-on-container-optimized-os.md
@@ -72,7 +72,16 @@ image](https://hub.docker.com/r/docker/compose/).
     Compose](https://hub.docker.com/r/docker/compose/tags/) to use the latest
     version.
 
-        docker run docker/compose:1.13.0 version
+        docker run docker/compose:1.24.0 version
+
+1.  Ensure your location is a writable directory.
+
+    Many directories are [mounted as read-only in the Container-Optimized
+    OS](/container-optimized-os/docs/concepts/disks-and-filesystem). Change
+    to a writable directory such as your home directory.
+
+        $ pwd
+        /home/username/dockercloud-hello-world
 
 1.  Run the Docker Compose command to run the sample code.
 
@@ -81,13 +90,13 @@ image](https://hub.docker.com/r/docker/compose/).
     option.
 
     To make the current directory available to the container, use the `-v
-    "$PWD:/rootfs/$PWD"` option to mount it as a volume and the `-w="/rootfs/$PWD"` to
+    "$PWD:$PWD"` option to mount it as a volume and the `-w="$PWD"` to
     change the working directory.
 
         docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v "$PWD:/rootfs/$PWD" \
-            -w="/rootfs/$PWD" \
+            -v "$PWD:$PWD" \
+            -w="$PWD" \
             docker/compose:1.13.0 up
 
 1.  With the `docker run` command still running, open the [Google Cloud
@@ -112,8 +121,8 @@ create an alias for it.
 
         echo alias docker-compose="'"'docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v "$PWD:/rootfs/$PWD" \
-            -w="/rootfs/$PWD" \
+            -v "$PWD:$PWD" \
+            -w="$PWD" \
             docker/compose:1.13.0'"'" >> ~/.bashrc
 
 1.  Reload the Bash configuration.


### PR DESCRIPTION
This fixes an issue "Error response from daemon: error while creating
mount source path
'/rootfs/home/bargachayoub/developer-edition/configs/core.ini': mkdir
/rootfs: read-only file system".

Also, update the tag to the latest version (1.24.0).

Closes #583.