### PR TITLE
Fix typo in Runtime to runtime on line 239

### DIFF
--- a/tutorials/exposing-aspnet-webapi-using-dotnetcore-with-cloud-endpoints/index.md
+++ b/tutorials/exposing-aspnet-webapi-using-dotnetcore-with-cloud-endpoints/index.md
@@ -236,7 +236,7 @@ latest version of Cloud Endpoints service (the one that was deployed last).
 1.  Create `app.yaml` file in VS Code at `ExploreApiWithEndpointsCore` directory.
     The content of the file should be:
 
-        Runtime: aspnetcore
+        runtime: aspnetcore
         env: flex
         endpoints_api_service:
             name: [SERVICE_NAME]


### PR DESCRIPTION
fix error [app.yaml] Unexpected attribute 'Runtime' for object of type AppInfoExternal.