### PR TITLE
Patch for new cloud build service account.

### DIFF
--- a/tutorials/create-cloud-build-image-factory-using-packer/index.md
+++ b/tutorials/create-cloud-build-image-factory-using-packer/index.md
@@ -81,7 +81,7 @@ PROJECT=$(gcloud config get-value project)
 
 First find the cloudbuild service account. Next add the editor role to it.
 
-    CLOUD_BUILD_ACCOUNT=$(gcloud projects get-iam-policy $PROJECT --filter="(bindings.role:roles/cloudbuild)"  --flatten="bindings[].members" --format="value(bindings.members[])")
+    CLOUD_BUILD_ACCOUNT=$(gcloud projects get-iam-policy $PROJECT --filter="(bindings.role:roles/cloudbuild.builds.builder)"  --flatten="bindings[].members" --format="value(bindings.members[])")
 
     gcloud projects add-iam-policy-binding $PROJECT \
       --member $CLOUD_BUILD_ACCOUNT \


### PR DESCRIPTION
A new cloud build service account was introduced that breaks this command. 