### PR TITLE
Terraform tutorial update

### DIFF
--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -197,7 +197,7 @@ instance. [More information on managing ssh keys is available here](https://clou
 ```HCL
 resource "google_compute_instance" "default" {
  ...
-metadata {
+metadata = {
    sshKeys = "INSERT_USERNAME:${file("~/.ssh/id_rsa.pub")}"
  }
 }

--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -1,43 +1,41 @@
 ---
 title: Getting started with Terraform on Google Cloud Platform
-description: Learn how to get a simple web server running on Google Compute Engine using Terraform to do the provisioning of resources.
+description: Learn how to get a simple web server running on Compute Engine using Terraform to do the provisioning of resources.
 author: chrisst
 tags: terraform
 date_published: 2018-08-17
 ---
 
-# Terraform on Google Cloud Platform
-
 One of the things I find most time consuming when starting on a new stack or
 technology is moving from reading documentation to a working prototype serving
-http requests. This can be especially frustrating when trying to tweak
-configurations and keys as it can be hard to make incremental progress. However
-once I have a shell of a web service stood up I can add features, connect to
-other apis, or add a datastore. I'm able to iterate very quickly with feedback
+HTTP requests. This can be especially frustrating when trying to tweak
+configurations and keys, as it can be hard to make incremental progress. However,
+once I have a shell of a web service stood up, I can add features, connect to
+other APIs, or add a datastore. I'm able to iterate very quickly with feedback
 at each step of the process. To help get through those first set up steps I've
-written this tutorial to cover:
+written this tutorial to cover the following:
 
-* Using Terraform to create a VM in Google Cloud Platform
+* Using Terraform to create a VM in Google Cloud Platform (GCP)
 * Starting a basic Python Flask server
 
 ### Before you begin
 
-You will be spinning up a single Google Compute Engine VM instance which can
+You will be spinning up a single Compute Engine VM instance, which can
 incur real, although usually minimal, costs. Pay attention to the pricing on the
-account. If you don't already have a Google Cloud Platform account you can
+account. If you don't already have a GCP account, you can
 [sign up for a free trial](https://cloud.google.com/free) and get $300 of free
-credit which is way more than you'll need in this tutorial.
+credit, which is more than you'll need for this tutorial.
 
 Have the following tools locally:
 
-* [An existing ssh key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
+* [An existing SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
 * [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 
-## Create a Google Cloud Platform project
+## Create a GCP project
 
-A default project is often set up by default for brand new accounts, but you
-will start by creating a brand new project to keep this separate and easy to
-tear down later. After creating it be sure to copy down the `project id` as it
+A default project is often set up by default for new accounts, but you
+will start by creating a new project to keep this separate and easy to
+tear down later. After creating it, be sure to copy down the `project id` as it
 is usually different then the `project name`.
 
 ![How to find your project id.][image1]
@@ -46,11 +44,11 @@ is usually different then the `project name`.
 
 ### Getting project credentials
 
-Next, set up a service account key which Terraform will use to create and manage
-resources in your Google Cloud Platform project. Go to the
+Next, set up a service account key, which Terraform will use to create and manage
+resources in your GCP project. Go to the
 [create service account key page](https://console.cloud.google.com/apis/credentials/serviceaccountkey).
 Select the default service account or create a new one, select JSON as the key
-type and hit **Create**.
+type, and click **Create**.
 
 This downloads a JSON file with all the credentials that will be needed for
 Terraform to manage the resources. This file should be located in a secure place
@@ -60,8 +58,8 @@ the project directory.
 ### Setting up Terraform
 
 Create a new directory for the project to live and create a `main.tf` file for
-the Terraform config. The contents of this file describe all of the Google
-Cloud Platform resources which will be used in the project.
+the Terraform config. The contents of this file describe all of the GCP
+resources that will be used in the project.
 
 ```HCL
 // Configure the Google Cloud provider
@@ -72,7 +70,7 @@ provider "google" {
 }
 ```
 
-Set the project id from the first step to the `project` property and point the
+Set the project ID from the first step to the `project` property and point the
 credentials section to the file that was downloaded in the last step. The
 `provider “google”` line indicates that you are using the
 [Google Cloud Terraform provider](https://www.terraform.io/docs/providers/google/index.html)
@@ -99,12 +97,12 @@ suggested below.
 Terraform has been successfully initialized!
 ```
 
-### Configure the Google Cloud Engine resource
+### Configure the Compute Engine resource
 
-Next you will create a single Google Cloud Engine instance running debian. For
+Next you will create a single Compute Engine instance running Debian. For
 this demo you can use the smallest instance possible (check out
 [all machine types here](https://cloud.google.com/compute/docs/machine-types))
-but Terraform/Google Cloud Platform makes it possible to upgrade to a larger
+but Terraform/GCP makes it possible to upgrade to a larger
 instance later. Add the `google_compute_instance` resource to the `main.tf`:
 
 ```HCL
@@ -139,12 +137,11 @@ resource "google_compute_instance" "default" {
 ```
 
 The [`random_id` Terraform plugin](https://www.terraform.io/docs/providers/random/r/id.html)
-allows you to create a somewhat random instance name that still complies Google
-Cloud Platform's instance naming requirements but requires an additional plugin.
-To download and install the extra plugin run `terraform init` again.
+allows you to create a somewhat random instance name that still complies with GCP's instance
+naming requirements but requires an additional plugin.
+To download and install the extra plugin, run `terraform init` again.
 
-
-### Validate the new Google Cloud Engine instance
+### Validate the new Compute Engine instance
 
 You can now validate the work that has been done so far! Run `terraform plan`
 which will:
@@ -176,22 +173,20 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 ```
 
 
-Now it's time to run `terraform apply` and Terraform will call Google Cloud
-Platform apis to set up the new instance! Check the
-[VM Instances page in the Google Cloud Platform UI](https://console.cloud.google.com/compute/instances)
-and the new instance will be there.
+Now it's time to run `terraform apply` and Terraform will call GCP APIs to set up the new instance! Check the
+[VM Instances page](https://console.cloud.google.com/compute/instances), and the new instance will be there.
 
-## Running a server on Google Cloud Platform
+## Running a server on GCP
 
-There is now a new instance running in Google Cloud Platform so your next steps
-are getting a web application created, deployed to the instance and exposing an
+There is now a new instance running in GCP, so your next steps
+are getting a web application created, deploying it to the instance, and exposing an
 endpoint for consumption.
 
-### Add ssh access to the Google Cloud Engine instance
+### Add SSH access to the Compute Engine instance
 
-You will need to add a public ssh key to the Google Cloud Engine instance to
+You will need to add a public SSH key to the Compute Engine instance to
 access and manage it. Add the local location of your public key to the
-`google_compute_instace` metadata in `main.tf` to add your ssh key to the
+`google_compute_instace` metadata in `main.tf` to add your SSH key to the
 instance. [More information on managing ssh keys is available here](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys).
 
 ```HCL
@@ -223,9 +218,9 @@ Terraform will perform the following actions:
 Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
 ```
 
-### Use output variables for the ip address
+### Use output variables for the IP address
 
-Use [a terraform output variable](https://www.terraform.io/intro/getting-started/outputs.html)
+Use [a Terraform output variable](https://www.terraform.io/intro/getting-started/outputs.html)
 to act as a helper to expose the instance's ip address. Add the following to
 the Terraform config:
 
@@ -237,21 +232,24 @@ output "ip" {
 ```
 
 Run `terraform apply` followed by `terraform output ip` to return the instance's
-external ip address. Validate that everything is set up correctly at this point
-by ssh'ing to that ip address.
+external IP address. Validate that everything is set up correctly at this point
+by connecting to that IP address with SSH.
 
-Note that this tutorial needs the `default` network's `default-allow-ssh` firewall rule to be in place before you can ssh to the instance. If you are starting with a brand new project this can take a few minutes to complete so check https://console.cloud.google.com/networking/firewalls/list to make sure it's created.
+Note: This tutorial needs the `default` network's `default-allow-ssh` firewall rule to be in place before you can use SSH 
+to connect to the instance. If you are starting with a new project, this can take a few minutes. You can
+check the [firewall rules list](https://console.cloud.google.com/networking/firewalls/list) to make sure that the 
+firewall rule has been created.
 
 ```Shell
 ssh `terraform output ip`
 ```
 
-## Building the flask app
+## Building the Flask app
 
 You will be building [a Python Flask app](http://flask.pocoo.org/) for this
 tutorial so that you can have a single file describing your web server and test
 endpoints. Inside the VM instance, add the following to a new file called
-`app.py`
+`app.py`:
 
 ```python
 from flask import Flask
@@ -264,20 +262,20 @@ def hello_cloud():
 app.run(host='0.0.0.0')
 ```
 
-Then run:
+Then run this command:
 
 ```Shell
 python app.py
 ```
 
-Flask serves traffic on `localhost:5000` by default. Run curl in a separate ssh
-instance to confirm that your greeting is being returned, however to hit this
-from your local computer you must expose port 5000.
+Flask serves traffic on `localhost:5000` by default. Run `curl` in a separate SSH
+instance to confirm that your greeting is being returned. To connect to this
+from your local computer, you must expose port 5000.
 
 ### Open port 5000 on the instance
 
-Google Cloud Platform allows for opening ports to traffic via firewall policies,
-which can also be managed in your Terraform config. Add the following to the
+GCP allows for opening ports to traffic via firewall policies,
+which can also be managed in your Terraform configuration. Add the following to the
 config and proceed to run plan/apply to create the firewall rule.
 
 ```HCL
@@ -292,12 +290,12 @@ resource "google_compute_firewall" "default" {
 }
 ```
 
-Congratulations, you can now point your browser to the instance's ip address and
-port 5000 and see your server running!
+Congratulations! You can now point your browser to the instance's IP address and
+port 5000 and see your server running.
 
 ## Cleaning up
 
-Now that you are finished with the tutorial you will likely want to tear down
+Now that you are finished with the tutorial, you will likely want to tear down
 everything that was created so that you don't incur any further costs.
 Thankfully, Terraform will let you remove all the resources defined in the
 configuration file with `terraform destroy`:

--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -240,6 +240,8 @@ Run `terraform apply` followed by `terraform output ip` to return the instance's
 external ip address. Validate that everything is set up correctly at this point
 by ssh'ing to that ip address.
 
+Note that this tutorial needs the `default` network's `default-allow-ssh` firewall rule to be in place before you can ssh to the instance. If you are starting with a brand new project this can take a few minutes to complete so check https://console.cloud.google.com/networking/firewalls/list to make sure it's created.
+
 ```Shell
 ssh `terraform output ip`
 ```


### PR DESCRIPTION
Updating the example for Terraform 0.12 syntax.
Adding a caveat that users will need to wait for default firewalls to be set up.

Discovered in https://github.com/GoogleCloudPlatform/community/issues/883