### PR TITLE
Update nginx-ingress-gke tutorial

### DIFF
--- a/tutorials/nginx-ingress-gke/index.md
+++ b/tutorials/nginx-ingress-gke/index.md
@@ -212,7 +212,7 @@ solution on Kubernetes Engine.
 
 If your Kubernetes cluster has RBAC enabled, from the Cloud Shell, deploy an NGINX controller Deployment and Service by running the following command:
 
-    helm install --name nginx-ingress stable/nginx-ingress --set rbac.create=true
+    helm install --name nginx-ingress stable/nginx-ingress --set rbac.create=true --set controller.publishService.enabled=true
 
 #### Deploy NGINX Ingress Controller with RBAC disabled
 


### PR DESCRIPTION
Add `publishService` to publish the right ip in ingress resources.

The tutorial does not include the `controller.publishService.enabled` flag for installation of nginx-ingress. Without this flag a wrong IP will be published in the status of the ingress resource. 

This is documented in [issue 4092 on nginx-ingress](https://github.com/kubernetes/ingress-nginx/issues/4092). See also the [nginx-ingress Readme](https://github.com/helm/charts/blob/master/stable/nginx-ingress/README.md#configuration).

See also #891 