### PR TITLE
Fix formatting error for elixir sample with cloud build

### DIFF
--- a/tutorials/elixir-phoenix-on-kubernetes-google-container-engine/index.md
+++ b/tutorials/elixir-phoenix-on-kubernetes-google-container-engine/index.md
@@ -482,7 +482,7 @@ your Docker image in the cloud and store the resulting Docker image in the
 
         steps:
         - name: "gcr.io/cloud-builders/docker"
-        args: ["build", "-t", "gcr.io/$PROJECT_ID/hello:$_TAG",
+          args: ["build", "-t", "gcr.io/$PROJECT_ID/hello:$_TAG",
                "--build-arg", "project_id=$PROJECT_ID", "."]
         images: ["gcr.io/$PROJECT_ID/hello:$_TAG"]
 


### PR DESCRIPTION
Minor nit: Args is spaced incorrectly for the yaml file and will lead to a build error when running "gcloud builds submit". 

