### PR TITLE
Fix metadata key for SSH keys

### DIFF
--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -193,7 +193,7 @@ instance. [More information on managing ssh keys is available here](https://clou
 resource "google_compute_instance" "default" {
  ...
 metadata = {
-   sshKeys = "INSERT_USERNAME:${file("~/.ssh/id_rsa.pub")}"
+   ssh-keys = "INSERT_USERNAME:${file("~/.ssh/id_rsa.pub")}"
  }
 }
 ```


### PR DESCRIPTION
Following [Managing SSH Keys in Metadata](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys) guidelines the metadata key should be `ssh-keys` and not `sshKeys`