### PR TITLE
fix for "terraform init"

### DIFF
--- a/tutorials/managing-gcp-projects-with-terraform/index.md
+++ b/tutorials/managing-gcp-projects-with-terraform/index.md
@@ -134,7 +134,6 @@ terraform {
  backend "gcs" {
    bucket  = "${TF_ADMIN}"
    prefix  = "terraform/state"
-   project = "${TF_ADMIN}"
  }
 }
 EOF


### PR DESCRIPTION
"project" is no longer necessary.

Here's the CLI output when running the current tutorial version:

```
$ terraform init

Initializing the backend...

Error: "project": [REMOVED] Please remove this attribute. It is not used since the backend no longer creates the bucket if it does not yet exist.

```

Removing the `project` attribute actually fixes the issue.