### PR TITLE
Remove GOOGLE_CLOUD_PROJECT env var

### DIFF
--- a/tutorials/cloud-run-local-dev-docker-compose/index.md
+++ b/tutorials/cloud-run-local-dev-docker-compose/index.md
@@ -65,7 +65,6 @@ services:
    environment:
      # https://cloud.google.com/run/docs/reference/container-contract
      PORT: ${PORT:-8080}
-     GOOGLE_CLOUD_PROJECT: my-project-name
      K_SERVICE: sample-app
      K_REVISION: 0
      K_CONFIGURATION: sample-app 


### PR DESCRIPTION
GOOGLE_CLOUD_PROJECT is not part of the Cloud Run container contract: https://cloud.google.com/run/docs/reference/container-contract#env-vars