### PR TITLE
Fix incorrect OAuth 2.0 RFC link

### DIFF
--- a/tutorials/understanding-oauth2-and-deploy-a-basic-auth-srv-to-cloud-functions/index.md
+++ b/tutorials/understanding-oauth2-and-deploy-a-basic-auth-srv-to-cloud-functions/index.md
@@ -88,7 +88,7 @@ Use the [Pricing Calculator](https://cloud.google.com/products/calculator/) to g
 
 ### OAuth 2.0
 
-OAuth 2.0 ([RFC 6479](https://tools.ietf.org/html/rfc6479)) is a widely used authorization framework enabling applications to access resources in all kinds of services. More specifically, OAuth 2.0 allows arbitrary **clients** (for example, a highly trusted first-party mobile app or a less trusted third-party web app) to access user’s (**resource owner**’s) resources on **resource servers** via **authorization servers** in a secure, reliable, and efficient manner.
+OAuth 2.0 ([RFC 6749](https://tools.ietf.org/html/rfc6749)) is a widely used authorization framework enabling applications to access resources in all kinds of services. More specifically, OAuth 2.0 allows arbitrary **clients** (for example, a highly trusted first-party mobile app or a less trusted third-party web app) to access user’s (**resource owner**’s) resources on **resource servers** via **authorization servers** in a secure, reliable, and efficient manner.
 
 ### Authorization Flows
 


### PR DESCRIPTION
The link to the OAuth 2.0 RFC was pointing at RFC 6479 (IPsec Anti-Replay Algorithm without Bit Shifting) instead RFC 6749 (The OAuth 2.0 Authorization Framework). I've fixed the text and the link