### PR TITLE
Add "engines" key to functions/package.json

### DIFF
--- a/tutorials/cloud-iot-firestore-config/functions/package.json
+++ b/tutorials/cloud-iot-firestore-config/functions/package.json
@@ -29,5 +29,8 @@
     "tslint": "^5.8.0",
     "typescript": "~2.8.3"
   },
+  "engines": {
+    "node": "8"
+  },
   "private": true
 }


### PR DESCRIPTION
Fix `Engines field is required but was not found in functions/package.json.` error. Same fix as https://github.com/firebase/quickstart-js/pull/335