### PR TITLE
iot: add virtual environment setup instructions for gateway tutorial

### DIFF
--- a/tutorials/cloud-iot-gateways-rpi/index.md
+++ b/tutorials/cloud-iot-gateways-rpi/index.md
@@ -92,7 +92,9 @@ First, create a device registry that will contain your gateway and devices.
 
 ## Set up your gateway
 
-For the purposes of this tutorial, you will use your laptop or desktop as the gateway device. You will first generate an RSA public/private key pair, which will be used to sign the JWTs for authenticating to Cloud IoT Core.
+For the purposes of this tutorial, you can use your laptop or desktop as the gateway device for a simpler setup process. Alternatively, you can use a more realistic device like an additional Raspberry Pi*.
+
+You will first generate an RSA public/private key pair, which will be used to sign the JWTs for authenticating to Cloud IoT Core.
 
 To set up your gateway:
 
@@ -123,21 +125,27 @@ To set up your gateway:
 
         wget https://pki.goog/roots.pem
 
-12. Install the following packages by running the following command. Feel free to do this in a virtual environment of your choice.
+12. Use a [virtual environment](https://virtualenv.pypa.io/en/stable/userguide/) to keep installations local to a workspace rather than installing libraries onto your system directly.
+
+        pip install virtualenv
+        virtualenv env
+        source env/bin/activate
+
+13. Install the following packages by running the following command.
 
         pip install -r requirements-gateway.txt
 
-13. Run the following command to start the gateway:
+14. Run the following command to start the gateway:
 
         source run-gateway
 
-14. Keep this process running while you proceed through the next steps. We recommend that you use a new tab or window for each gateway and device.
+15. Keep this process running while you proceed through the next steps. We recommend that you use a new tab or window for each gateway and device.
 
-15. Find the local IP address of the gateway using `ifconfig` on  Mac/Linux or `ipconfig /all` on Windows. Copy this somewhere as you will need to add this IP address to `led-light.py` and `thermostat.py` later for connecting devices to the gateway. Your gateway and devices need to be on the same network and be visible to each other.
+16. Find the local IP address of the gateway using `ifconfig` on  MacOS/Linux or `ipconfig /all` on Windows. Copy this somewhere as you will need to add this IP address to `led-light.py` and `thermostat.py` later for connecting devices to the gateway. Your gateway and devices need to be on the same network and be visible to each other.
 
 ## Raspberry Pi setup
 
-In this tutorial, you'll use a [Raspberry Pi*][rpi] to manage the LED/temperature sensor. Devices will connect to the gateway device through [UDP sockets][udp-socket] over a local network, which will connect to Cloud IoT Core via the [MQTT bridge][mqtt-bridge]. A Raspberry Pi could theoretically connect directly to the cloud (since the Pi can connect to the internet), so using a Raspberry Pi for this part is mostly for demonstration purposes.
+In this tutorial, you'll use a [Raspberry Pi*][rpi] to manage the LED/temperature sensor. Devices will connect to the gateway device through [UDP sockets][udp-socket] over a local network, which will connect to Cloud IoT Core via the [MQTT bridge][mqtt-bridge]. The Raspberry Pi is not really a constrained device since it has IP connectivity and the ability to sign JWTs, so its use here is mostly for demonstration purposes.
 
 1. [Download Raspbian][raspbian-download] (the full image with Desktop and recommended software) and follow [the installation guide][raspbian-installation] to flash Raspbian onto your microSD card.
 2. Insert the microSD card with Raspbian into your Raspberry Pi.
@@ -157,11 +165,15 @@ In this tutorial, you'll use a [Raspberry Pi*][rpi] to manage the LED/temperatur
         git clone https://github.com/GoogleCloudPlatform/community.git
         cd community/tutorials/cloud-iot-gateways-rpi
 
-9. Install Python dependencies by running the following:
+9. Create and activate your virtual environment. Make sure to run the last step whenever you open a new tab to activate the virtual environment.
+
+        pip install virtualenv
+        virtualenv env
+        source env/bin/activate
+
+10. Install Python dependencies by running the following:
 
         pip install -r requirements-pi.txt
-
-    Feel free to do this part in the virtual environment manager of your choosing, though make sure to switch into those environments when opening new tabs.
 
 [udp-socket]: https://docs.python.org/2/library/socket.html
 [mqtt-bridge]: https://cloud.google.com/iot/docs/how-tos/mqtt-bridge
@@ -252,7 +264,7 @@ To avoid incurring any future billing costs, it is recommended that you delete y
 - The reason why **Association Only** was chosen when creating the gateway is so that the device does not have to store its own JWT when authenticating to Cloud IoT Core. You can read more about [authentication methods here][iot-auth].
 - You can set up a second Raspberry Pi or another internet enabled device to act as the gateway for a more realistic example.
 - A slightly less expensive alternative to the DHT22 is the [DHT11][dht-alt].
-- If you have difficulty installing the packages from `requirements-pi.txt`, make sure you are on the latest version of Raspbian. In addition, [updating some packages could solve the issue][installation-issue].
+- If you encounter issues while installing the packages from `requirements-pi.txt`, make sure you are on the latest version of Raspbian. In addition, [updating some packages could solve the issue][installation-issue].
 
         sudo apt-get install build-essential libssl-dev libffi-dev python-dev
 

--- a/tutorials/cloud-iot-gateways-rpi/index.md
+++ b/tutorials/cloud-iot-gateways-rpi/index.md
@@ -9,9 +9,13 @@ date_published: 2018-12-10
 Alex Hong | Developer Programs Engineer | Google Cloud IoT Core  
 Fengrui Gu | Software Engineer | Google Cloud IoT Core
 
-This tutorial shows you how to set up and use gateways on Cloud IoT Core. From the [documentation][gateways-overview], a "gateway is a device that connects less capable devices to Cloud IoT Core and performs several tasks on the device's behalf, such as communication, authentication, storage, and processing."
+This tutorial shows you how to set up and use gateways on Cloud IoT Core. From the [documentation][gateways-overview], a 
+"gateway is a device that connects less capable devices to Cloud IoT Core and performs several tasks on the device's behalf,
+such as communication, authentication, storage, and processing."
 
-In this tutorial, you will create a gateway that manages two devices: a simple LED and a DHT22 sensor. Neither device will be directly connected to Cloud IoT Core, but will receive updates from and publish telemetry events to the cloud through the gateway.
+In this tutorial, you will create a gateway that manages two devices: a simple LED and a DHT22 sensor. Neither device will
+be directly connected to Cloud IoT Core, but will receive updates from and publish telemetry events to the cloud through the
+gateway.
 
 [gateways-overview]: https://cloud.google.com/iot/docs/how-tos/gateways/
 
@@ -125,7 +129,8 @@ To set up your gateway:
 
         wget https://pki.goog/roots.pem
 
-12. Use a [virtual environment](https://virtualenv.pypa.io/en/stable/userguide/) to keep installations local to a workspace rather than installing libraries onto your system directly.
+12. Use a [virtual environment](https://virtualenv.pypa.io/en/stable/userguide/) to keep installations local to a
+    workspace rather than installing libraries onto your system directly.
 
         pip install virtualenv
         virtualenv env
@@ -147,25 +152,28 @@ To set up your gateway:
 
 In this tutorial, you'll use a [Raspberry Pi*][rpi] to manage the LED/temperature sensor. Devices will connect to the gateway device through [UDP sockets][udp-socket] over a local network, which will connect to Cloud IoT Core via the [MQTT bridge][mqtt-bridge]. The Raspberry Pi is not really a constrained device since it has IP connectivity and the ability to sign JWTs, so its use here is mostly for demonstration purposes.
 
-1. [Download Raspbian][raspbian-download] (the full image with Desktop and recommended software) and follow [the installation guide][raspbian-installation] to flash Raspbian onto your microSD card.
-2. Insert the microSD card with Raspbian into your Raspberry Pi.
-3. Attach a power source to the Raspberry Pi using the microUSB cable (e.g., to a laptop USB port).
-4. Connect your keyboard and mouse to the Raspberry Pi's USB ports.
-5. Connect the Raspberry Pi to a monitor through the HDMI port.
-6. Go through the default setup steps for Raspbian upon boot.
-7. Open a terminal and make sure `git`, `python` (python2), and other required dependencies are installed. If not, install them by running:
+1.  [Download Raspbian][raspbian-download] (the full image with Desktop and recommended software) and
+    follow [the installation guide][raspbian-installation] to flash Raspbian onto your microSD card.
+2.  Insert the microSD card with Raspbian into your Raspberry Pi.
+3.  Attach a power source to the Raspberry Pi using the microUSB cable (e.g., to a laptop USB port).
+4.  Connect your keyboard and mouse to the Raspberry Pi's USB ports.
+5.  Connect the Raspberry Pi to a monitor through the HDMI port.
+6.  Go through the default setup steps for Raspbian upon boot.
+7.  Open a terminal and make sure `git`, `python` (python2), and other required dependencies are installed. If not, install
+    them by running:
 
         sudo apt update && sudo apt upgrade
         sudo apt install git
         sudo apt install python
         sudo apt install build-essential libssl-dev libffi-dev python-dev
 
-8. Clone the following repository and change into the directory for this tutorial's code:
+8.  Clone the following repository and change into the directory for this tutorial's code:
 
         git clone https://github.com/GoogleCloudPlatform/community.git
         cd community/tutorials/cloud-iot-gateways-rpi
 
-9. Create and activate your virtual environment. Make sure to run the last step whenever you open a new tab to activate the virtual environment.
+9.  Create and activate your virtual environment. Make sure to run the last step whenever you open a new tab to activate the
+    virtual environment.
 
         pip install virtualenv
         virtualenv env
@@ -185,13 +193,13 @@ In this tutorial, you'll use a [Raspberry Pi*][rpi] to manage the LED/temperatur
 
 Next, you will manage an LED light connected to the gateway through Cloud IoT Core config updates.
 
-1. Switch to your browser and open the [Cloud IoT Core console][cloud-iot].
-2. Click on the registry you created.
-        The gateway you created should be listed in this registry.
-3. Click **Create Device**.
-4. For **Device ID**, enter **led-light**.
-5. Leave everything else blank or as-is. You don't need to enter a public key since the device will be authenticated through the gateway.
-6. Bind the device to the gateway.
+1.  Switch to your browser and open the [Cloud IoT Core console][cloud-iot].
+2.  Click on the registry you created. The gateway you created should be listed in this registry.
+3.  Click **Create Device**.
+4.  For **Device ID**, enter **led-light**.
+5.  Leave everything else blank or as-is. You don't need to enter a public key since the device will be authenticated 
+    through the gateway.
+6.  Bind the device to the gateway.
     - Click the browser's button to return to your registry page.
     - Click on `my-gateway` from the **Gateways** tab in `my-registry`.
     - Click on the **Bound devices** tab.
@@ -199,9 +207,10 @@ Next, you will manage an LED light connected to the gateway through Cloud IoT Co
     - Confirm by clicking **Bind** in the lower right.
 
     ![bind device to gateway](https://storage.googleapis.com/gcp-community/tutorials/cloud-iot-gateways-rpi/bind-device.png)
-7. Edit `led-light.py` by adding the IP address of your gateway on line 28 `ADDR = ''`.
-8. Connect the LED to the Raspberry Pi's [GPIO Pin 4][rpi-gpio] and ground using an appropriate resistor.
-9. Ensure the gateway Python sample is still running on your desktop or laptop.
+    
+7.  Edit `led-light.py` by adding the IP address of your gateway on line 28 `ADDR = ''`.
+8.  Connect the LED to the Raspberry Pi's [GPIO Pin 4][rpi-gpio] and ground using an appropriate resistor.
+9.  Ensure the gateway Python sample is still running on your desktop or laptop.
 10. Run the following from your terminal on the Raspberry Pi:
 
         source run-led-light


### PR DESCRIPTION
Should resolve future issues that people have similar to #954 and #960.

* Add instructions for setting up virtual environments
* Improved wording for using raspberry pi