### PR TITLE
Runtime dependencies updated to match Cloud SQL MySQL version.

### DIFF
--- a/tutorials/deploy-grails-to-google-cloud/index.md
+++ b/tutorials/deploy-grails-to-google-cloud/index.md
@@ -359,9 +359,9 @@ production URL to use the Cloud SQL MySQL database which you created before.
 1.  Add the MySQL dependencies JDBC library and Cloud SQL MySQL Socket Factory:
 
     _build.gradle_
-
-        runtime 'mysql:mysql-connector-java:6.0.5'
-        runtime 'com.google.cloud.sql:mysql-socket-factory-connector-j-6:1.0.3'
+    
+        runtime 'mysql:mysql-connector-java:8.0.16'
+        runtime 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.0.14'
 
 1.  Replace the `production` environment `datasource` configuration to point to the
     Cloud SQL MySQL database in `application.yml`:


### PR DESCRIPTION
Cloud SQL now runs MySQL 5.7. I found I had to update the drivers to match it.