### PR TITLE
Updated google-cloud-storage dependency version.

### DIFF
--- a/tutorials/deploy-grails-to-google-cloud/index.md
+++ b/tutorials/deploy-grails-to-google-cloud/index.md
@@ -425,7 +425,7 @@ from live data serving to data analytics/ML to data archiving.
 
     _build.gradle_
 
-        compile 'com.google.cloud:google-cloud-storage:1.2.3'
+        compile 'com.google.cloud:google-cloud-storage:1.84.0'
 
 1.  Exclude `com.google.guava:guava-jdk5` too:
 


### PR DESCRIPTION
I found google-cloud-storage:1.2.3 resulted in method-overloading exceptions when calling storage.create() with no 'options'.
Upgrading to version 1.84.0 solved the issue.