### PR TITLE
fixes #993 Change wording Firestore in Native mode

### DIFF
--- a/tutorials/cloud-functions-firestore/index.md
+++ b/tutorials/cloud-functions-firestore/index.md
@@ -26,7 +26,7 @@ which you can simulate with `curl`.
 1.  Create a project in the [Google Cloud Platform Console][console].
 1.  Enable billing for your project.
 1.  [Enable the Google Cloud Functions API][enable_functions].
-1.  [Enable the Google Cloud Firestore API][enable_firestore] *(Datastore mode)*.
+1.  [Enable the Google Cloud Firestore API][enable_firestore] *(Cloud Firestore in [Native mode][native_mode])*.
 1.  Install and initialize the [Google Cloud SDK][sdk].
 
     1.  After initializing the SDK, configure the gcloud CLI for your project_id.
@@ -37,6 +37,7 @@ which you can simulate with `curl`.
 [enable_functions]: https://console.cloud.google.com/apis/api/cloudfunctions.googleapis.com/overview
 [enable_firestore]: https://console.cloud.google.com/firestore/welcome
 [sdk]: https://cloud.google.com/sdk/
+[native_mode]: https://cloud.google.com/firestore/docs/firestore-or-datastore
 
 This guide uses `cloud-functions-firestore` as the project_id, as well as the firestore collection.
 

--- a/tutorials/cloud-functions-firestore/index.md
+++ b/tutorials/cloud-functions-firestore/index.md
@@ -5,6 +5,7 @@ author: zeroasterisk
 tags: Cloud Functions, Cloud Datastore, Cloud Firestore
 date_published: 2018-12-29
 ---
+
 ## Introduction
 
 This tutorial demonstrates using
@@ -26,12 +27,11 @@ which you can simulate with `curl`.
 1.  Create a project in the [Google Cloud Platform Console][console].
 1.  Enable billing for your project.
 1.  [Enable the Google Cloud Functions API][enable_functions].
-1.  [Enable the Google Cloud Firestore API][enable_firestore] *(Cloud Firestore in [Native mode][native_mode])*.
+1.  [Enable the Google Cloud Firestore API][enable_firestore] (with Cloud Firestore in [Native mode][native_mode]).
 1.  Install and initialize the [Google Cloud SDK][sdk].
+1.  Configure the `gcloud` command-line interface for your project, replacing `[PROJECT_ID]` with your project ID:
 
-    1.  After initializing the SDK, configure the gcloud CLI for your project_id.
-
-        gcloud config set project <projectid>
+        gcloud config set project [PROJECT_ID]
 
 [console]: https://console.cloud.google.com/
 [enable_functions]: https://console.cloud.google.com/apis/api/cloudfunctions.googleapis.com/overview

--- a/tutorials/cloud-functions-firestore/index.md
+++ b/tutorials/cloud-functions-firestore/index.md
@@ -39,7 +39,7 @@ which you can simulate with `curl`.
 [sdk]: https://cloud.google.com/sdk/
 [native_mode]: https://cloud.google.com/firestore/docs/firestore-or-datastore
 
-This guide uses `cloud-functions-firestore` as the project_id, as well as the firestore collection.
+This guide uses `cloud-functions-firestore` as the project ID, as well as the firestore collection.
 
 ## Preparing the Cloud Function
 


### PR DESCRIPTION
Change wording from "datastore mode" to Cloud Firestore in Native mode, and linked to comparison doc.