### PR TITLE
Escapes brackets that are interpreted as Django tags.

### DIFF
--- a/tutorials/cloud-iot-prometheus-monitoring/index.md
+++ b/tutorials/cloud-iot-prometheus-monitoring/index.md
@@ -550,8 +550,8 @@ The chart that you deployed contains two preconfigured alerting rules:
               severity: page
               system: mechanical
             annotations:
-              summary: "Lid open on {{ $labels.instance }}"
-              description: "Lid has remained open for more than 15 minutes on {{ $labels.instance }}"
+              summary: "Lid open on {% verbatim %}{{ $labels.instance }}{% endverbatim %}"
+              description: "Lid has remained open for more than 15 minutes on {% verbatim %}{{ $labels.instance }}{% endverbatim %}"
           - alert: DeviceRebooting
             expr: changes(device_boot_time[1h]) > 20
             for: 2m
@@ -559,8 +559,8 @@ The chart that you deployed contains two preconfigured alerting rules:
               severity: debug
               system: software
             annotations:
-              summary: "{{ $labels.instance }} rebooting"
-              description: "{{ $labels.instance }} has been rebooting more than 20 times an hour"
+              summary: "{% verbatim %}{{ $labels.instance }}{% endverbatim %} rebooting"
+              description: "{% verbatim %}{{ $labels.instance }}{% endverbatim %} has been rebooting more than 20 times an hour"
 ```
 
 We can see in these rules the Prometheus query to run, along with threshold time required for the alert to fire.

--- a/tutorials/continuous-deployment-pipeline-google-container-engine-with-codeship/index.md
+++ b/tutorials/continuous-deployment-pipeline-google-container-engine-with-codeship/index.md
@@ -137,7 +137,7 @@ Codeship Jet CLI.
       service: app
       type: push
       image_name: "gcr.io/YOUR_PROJECT_ID/hello-express" #update this line using your Google Cloud Platform project ID
-      image_tag: "{{printf \"%.8s\" .CommitID}}"
+      image_tag: "{% verbatim %}{{printf \"%.8s\" .CommitID}}{% endverbatim %}"
       registry: https://gcr.io
       dockercfg_service: codeship_gcr_dockercfg
     - name: tag-as-master

--- a/tutorials/gke-networking-fundamentals/index.md
+++ b/tutorials/gke-networking-fundamentals/index.md
@@ -1435,7 +1435,7 @@ kubectl get pod $PODNAME -o=jsonpath='{.status.hostIP}'
 Now that you have the IP address, use SSH to connect to the host running the container, then get the PID of the container:
 
 ```
-PID=$(docker inspect --format '{{ .State.Pid }}' $ContainerID)
+PID=$(docker inspect --format '{% verbatim %}{{ .State.Pid }}{% endverbatim %}' $ContainerID)
 ```
 
 Get the host running the container:


### PR DESCRIPTION
The three files in this PR are trying to print `{{ text }}` as part of the
tutorial text, which the template engine interprets as Django variables. The
`{{ text }}` should be printed as is.

Per the Django documentation, we can use the [`{{ verbatim }}`][0] tag to stop
the template engine from rendering the contents of this block tag.

[0]: https://docs.djangoproject.com/en/2.2/ref/templates/builtins/#verbatim