### PR TITLE
fix minor typo in GCP Terraform Tutorial

### DIFF
--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -186,7 +186,7 @@ endpoint for consumption.
 
 You will need to add a public SSH key to the Compute Engine instance to
 access and manage it. Add the local location of your public key to the
-`google_compute_instace` metadata in `main.tf` to add your SSH key to the
+`google_compute_instance` metadata in `main.tf` to add your SSH key to the
 instance. [More information on managing ssh keys is available here](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys).
 
 ```HCL


### PR DESCRIPTION
change `instace` to `instance` in section `Add SSH access to the Compute Engine instance`