### PR TITLE
update docker-gcplogs-driver links

### DIFF
--- a/tutorials/docker-gcplogs-driver/index.md
+++ b/tutorials/docker-gcplogs-driver/index.md
@@ -2,7 +2,7 @@
 title: Using the Google Cloud Logging Driver for Docker
 description: Learn to use the gcplogs logging driver to save your Docker logs to Stackdriver Logging.
 author: tswast
-tags: Docker, Logging
+tags: Docker, Logging, devops
 date_published: 2017-04-24
 ---
 This tutorial shows you how to use the [Google Cloud logging
@@ -28,7 +28,7 @@ containers](https://docs.docker.com/engine/admin/logging/overview/) to
 
 This tutorial uses billable components of Cloud Platform including
 
-- [Google Compute Engine](/compute/pricing)
+- [Google Compute Engine](/compute/all-pricing)
 - [Stackdriver Logging](/stackdriver/pricing)
 
 Use the [Pricing Calculator](/products/calculator/) to estimate the costs for
@@ -38,13 +38,14 @@ your usage.
 
 Create a new Compute Engine instance using the [Container-Optimized
 OS](/container-optimized-os/) stable image. Container-Optimized OS comes
-with [Docker](https://www.docker.com/what-docker) pre-installed and supports
+with [Docker](https://www.docker.com/why-docker) pre-installed and supports
 automatic system updates.
 
 1.  Open the [Google Cloud Platform console](https://console.cloud.google.com).
 1.  [Create a new Compute Engine instance](https://console.cloud.google.com/compute/instancesAdd).
 1.  Select the desired **Zone**, such as "us-central1-f".
-1.  Select the desired **Machine type**, such as "micro" (f1-micro).
+1.  Select the desired **Machine series**, such as "N1".
+1.  Select the desired **Machine type**, such as "f1-micro".
 1.  Change the **Boot disk** to "Container-Optimized OS stable".
 1.  Click the **Create** button to create the Compute Engine instance.
 
@@ -53,35 +54,30 @@ automatic system updates.
 1.  After the instance is created, click the **SSH** button to open a terminal
     connected to the machine.
 1.  To use the [Google Cloud logging driver for
-    Docker](https://docs.docker.com/engine/admin/logging/gcplogs/), specify the
+    Docker](https://docs.docker.com/config/containers/logging/gcplogs/), specify the
     `--log-driver=gcplogs` command-line argument to the `docker run` command.
 
     Run the following command to start an NGINX container which writes logs to
     Stackdriver Logging.
 
-        docker run -d --name mysite --log-driver=gcplogs -p 80:80 nginx
-
-    You can specify additional options with the `--log-opt` command-line
-    argument. This command tells Docker to also log the command that the container
-    was started with.
-
         docker run -d \
             --name mysite \
             --log-driver=gcplogs \
-            --log-opt gcp-log-cmd=true \
             -p 80:80 \
             nginx
 
-1.  Make a request to your container so that it logs something.
+1.  Make a request to your container, which will generate logs and push them
+    to Stackdriver.
 
         curl 127.0.0.1:80
 
 ## Configuring the Google Cloud logging driver with Docker Compose
 
-When using Docker Compose, specify a logging driver for each service in the
-`docker-compose.yml` configuration file. For example:
+When using Docker Compose, specify a [logging
+driver](https://docs.docker.com/compose/compose-file/#logging) for each
+service in the `docker-compose.yml` configuration file. For example:
 
-    version: '2'
+    version: '3'
     services:
       web:
         logging:
@@ -131,7 +127,7 @@ specify the `--log-driver=gcplogs` option in the `dockerd` command.
     dockerd --log-driver=gcplogs
 
 Container-Optimized OS starts [Docker using
-systemd](https://docs.docker.com/engine/admin/systemd/).  To configure Docker
+systemd](https://docs.docker.com/config/daemon/systemd/).  To configure Docker
 to use the Google Cloud logging driver when it is started by systemd:
 
 1.  Create `/etc/docker/daemon.json`.
@@ -145,7 +141,7 @@ to use the Google Cloud logging driver when it is started by systemd:
 1.  Test it out by running a container without specifying an explicit
     `--log-driver`.
 
-        docker run -d --name mysite -p 80:80 nginx
+        docker run -d --name mysite2 -p 80:80 nginx
 
     After making a few requests to this container, you should see the logs in
     the [Logs Viewer](https://console.cloud.google.com/logs/viewer) as you did
@@ -196,7 +192,7 @@ you can skip this section.*
 From [Google Cloud Shell](/shell/docs/quickstart) or a development machine
 where you have [installed and initialized the Google Cloud SDK](/sdk/docs/),
 use the [gcloud compute intances
-add-metadata](https://cloud.google.com/sdk/gcloud/reference/compute/instances/add-metadata)
+add-metadata](/sdk/gcloud/reference/compute/instances/add-metadata)
 command to add the `user-data` key to your instance.
 
 1.  Create a file `instance-config.txt` with the contents:
@@ -226,6 +222,5 @@ command to add the `user-data` key to your instance.
 
 - [Install the Stackdriver Logging Agent to stream system logs to Stackdriver
   Logging](/logging/docs/agent/installation).
-- [Try out some other Docker-related community
-  tutorials](/community/tutorials/?q=Docker).
+- [Try out some other DevOps tutorials](/docs/tutorials/#devops).
 

--- a/tutorials/docker-gcplogs-driver/index.md
+++ b/tutorials/docker-gcplogs-driver/index.md
@@ -9,7 +9,7 @@ This tutorial shows you how to use the [Google Cloud logging
 driver](https://docs.docker.com/engine/admin/logging/gcplogs/) to [upload logs
 from your Docker
 containers](https://docs.docker.com/engine/admin/logging/overview/) to
-[Stackdriver Logging](/logging/).
+[Stackdriver Logging](https://cloud.google.com/logging/).
 
 ## Objectives
 
@@ -28,16 +28,16 @@ containers](https://docs.docker.com/engine/admin/logging/overview/) to
 
 This tutorial uses billable components of Cloud Platform including
 
-- [Google Compute Engine](/compute/all-pricing)
-- [Stackdriver Logging](/stackdriver/pricing)
+- [Google Compute Engine](https://cloud.google.com/compute/all-pricing)
+- [Stackdriver Logging](https://cloud.google.com/stackdriver/pricing)
 
-Use the [Pricing Calculator](/products/calculator/) to estimate the costs for
+Use the [Pricing Calculator](https://cloud.google.com/products/calculator/) to estimate the costs for
 your usage.
 
 ## Setting up the virtual machine
 
 Create a new Compute Engine instance using the [Container-Optimized
-OS](/container-optimized-os/) stable image. Container-Optimized OS comes
+OS](https://cloud.google.com/container-optimized-os/) stable image. Container-Optimized OS comes
 with [Docker](https://www.docker.com/why-docker) pre-installed and supports
 automatic system updates.
 
@@ -149,14 +149,14 @@ to use the Google Cloud logging driver when it is started by systemd:
 
 ## Persisting configuration across reboots
 
-On [Container-Optimized OS](/container-optimized-os/), files in `/etc/` are
+On [Container-Optimized OS](https://cloud.google.com/container-optimized-os/), files in `/etc/` are
 writable, but [data does not persist across
-reboots](/container-optimized-os/docs/concepts/security#filesystem).
+reboots](https://cloud.google.com/container-optimized-os/docs/concepts/security#filesystem).
 Instead, [use cloud-init to configure Container-Optimized OS
-instances](/container-optimized-os/docs/how-to/create-configure-instance#using_cloud-init).
+instances](https://cloud.google.com/container-optimized-os/docs/how-to/create-configure-instance#using_cloud-init).
 
 To configure cloud-init, [update the instance
-metadata](/compute/docs/storing-retrieving-metadata#updatinginstancemetadata)
+metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#updatinginstancemetadata)
 by writing a configuration to the `user-data` key.
 
 You can write the configuration to the instance metadata from the command line
@@ -189,10 +189,10 @@ sections.
 *If you have already written the metadata using the Cloud Platform Console,
 you can skip this section.*
 
-From [Google Cloud Shell](/shell/docs/quickstart) or a development machine
-where you have [installed and initialized the Google Cloud SDK](/sdk/docs/),
+From [Google Cloud Shell](https://cloud.google.com/shell/docs/quickstart) or a development machine
+where you have [installed and initialized the Google Cloud SDK](https://cloud.google.com/sdk/docs/),
 use the [gcloud compute intances
-add-metadata](/sdk/gcloud/reference/compute/instances/add-metadata)
+add-metadata](https://cloud.google.com/sdk/gcloud/reference/compute/instances/add-metadata)
 command to add the `user-data` key to your instance.
 
 1.  Create a file `instance-config.txt` with the contents:
@@ -220,7 +220,7 @@ command to add the `user-data` key to your instance.
 
 ## Next steps
 
-- [Install the Stackdriver Logging Agent to stream system logs to Stackdriver
-  Logging](/logging/docs/agent/installation).
-- [Try out some other DevOps tutorials](/docs/tutorials/#devops).
+- [Install the Stackdriver Logging agent to stream system logs to Stackdriver
+  Logging](https://cloud.google.com/logging/docs/agent/installation).
+- [Try out some other DevOps tutorials](https://cloud.google.com/docs/tutorials/#devops).
 


### PR DESCRIPTION
When investigating #220, I found a few links that needed updating.