### PR TITLE
Update setting-up-redis.md

### DIFF
--- a/tutorials/setting-up-redis.md
+++ b/tutorials/setting-up-redis.md
@@ -95,10 +95,7 @@ running the Redis server.
 ## Configure Redis remote access
 
 By default, Redis doesn't allow remote connections. To change this setting,
-you can change the configuration in the [`redis.conf`](https://redis.io/topics/config) file, as described
-in the following sections.
-
-### Edit the `redis.conf` file
+you can change the configuration in the [`redis.conf`](https://redis.io/topics/config) file.
 
 1. In the SSH terminal window, edit the `redis.conf` file. This tutorial uses the
 `nano` editor, but you can substitute your favorite editor. Enter the following:

--- a/tutorials/setting-up-redis.md
+++ b/tutorials/setting-up-redis.md
@@ -185,7 +185,8 @@ an officially supported command-line tool to interact with a Redis server.
    external IP address of your Compute Engine instance in the **External IP** column.
 
 1. Ping the Redis server. Replace `[REDIS_IPV4_ADDRESS]` with the external IP address from the previous step
-   and `[YOUR_STRONG_PASSWORD]` with the password you defined in step 5 of the "Edit `redis.conf`" section:
+   and `[YOUR_STRONG_PASSWORD]` with the password you defined in step 5 of the "Configure Redis remote access"
+   section:
 
         redis-cli -h [REDIS_IPV4_ADDRESS] -a '[YOUR_STRONG_PASSWORD]' ping
 

--- a/tutorials/setting-up-redis.md
+++ b/tutorials/setting-up-redis.md
@@ -1,12 +1,13 @@
 ---
-title: How to Set Up Redis on Google Compute Engine
-description: Learn how to get Redis running on Google Compute Engine.
+title: How to set up Redis on Compute Engine
+description: Learn how to get Redis running on Compute Engine.
 author: chingor13
 tags: Compute Engine, Redis
 date_published: 2017-06-08
 ---
+
 This tutorial shows how to set up [Redis](https://redis.io/) on
-Google Cloud Platform in just a few minutes. Follow this tutorial to configure a standalone
+Google Cloud in just a few minutes. Follow this tutorial to configure a standalone
 Redis instance on a Debian 8 (jessie) virtual machine instance on Compute Engine.
 
 You can also use [Cloud Launcher](https://console.cloud.google.com/launcher/details/click-to-deploy-images/redis)
@@ -17,22 +18,21 @@ to set up Redis cluster on Compute Engine with just a few clicks.
 
 * Install Redis on a Compute Engine instance.
 * Configure Redis for remote access.
-* Configure a Cloud Platform firewall to open a port. (optional)
+* Configure a Google Cloud firewall to open a port. (optional)
 * Connect to Redis from a remote computer. (optional)
 
 ## Before you begin
 
-You'll need a Google Cloud Console project. You can use an existing project or
-click the button to create a new project.
+You'll need a Google Cloud project. You can use an existing project or
+click the following link to create a new project:
 
-**[Create a project](https://console.cloud.google.com/project)**
+[**Create a project**](https://console.cloud.google.com/project)
 
 ## Costs
 
-This tutorial uses billable components of Cloud Platform,
-including:
+This tutorial uses billable components of Google Cloud, including the following:
 
-+ Google Compute Engine
++ Compute Engine
 
 Use the [pricing calculator](https://cloud.google.com/products/calculator/#id=88a62458-4ab4-42fa-a7f3-e6b1d66bd307)
 to generate a cost estimate based on your projected usage. New Cloud Platform users might be
@@ -46,12 +46,12 @@ you don't need to change the default setting.
 In production, you need to decide how much computing power is required
 for your application. In general, database systems tend to be more
 constrained by I/O bottlenecks and hard disk speed than by CPU capabilities.
-Redis, in particular, relies heavily on memory so be sure to allocate enough memory for your use case.
+Redis, in particular, relies heavily on memory, so be sure to allocate enough memory for your use case.
 
 Most Linux distributions have some version of Redis integrated with
 their package managers. For this tutorial, you use Debian 8 (jessie) which includes Redis 2.8.
 
-1. In the Cloud Platform Console, go to the **[VM Instances](https://console.cloud.google.com/compute/instances)** page.
+1. In the Cloud Console, go to the [**VM Instances**](https://console.cloud.google.com/compute/instances) page.
 1. Click the **Create instance** button.
 1. Set Name to `redis-tutorial`.
 1. In the **Boot disk** section, click **Change** to begin configuring your boot disk.
@@ -69,7 +69,8 @@ Stay on the **VM instances** page for the next step.
 
 Follow these steps to install Redis on your Compute Engine instance.
 
-1. In the list of virtual machine instances, click the **SSH** button in the row of the instance to which you want to connect.
+1. In the list of virtual machine instances, click the **SSH** button in the row of the
+   instance to which you want to connect.
 1. Update the Debian packages list. In the SSH terminal, enter the following command:
 
         sudo apt-get update
@@ -82,29 +83,29 @@ Follow these steps to install Redis on your Compute Engine instance.
 
         ps -f -u redis
 
-   You should see something like:
+   You should see something like the following:
 
         yourname@redis-tutorial:~$ ps -f -u redis
         UID        PID  PPID  C STIME TTY          TIME CMD
         redis      802     1  0 21:07 ?        00:00:00 /usr/bin/redis-server 127.0.0.1:6379
 
-Congratulations, Redis is running, but will only accept connections from `127.0.0.1` - the local machine
+Congratulations! Redis is running, but will only accept connections from `127.0.0.1`, the local machine
 running the Redis server.
 
 ## Configure Redis remote access
 
 By default, Redis doesn't allow remote connections. To change this setting,
-you can change the configuration in the [`redis.conf`](https://redis.io/topics/config) file.
-Follow these steps.
+you can change the configuration in the [`redis.conf`](https://redis.io/topics/config) file, as described
+in the following sections.
 
-### Edit `redis.conf`
+### Edit the `redis.conf` file
 
-1. In the SSH terminal window, edit `redis.conf`. This tutorial uses the
-`nano` editor, but you can substitute your favorite editor. Enter:
+1. In the SSH terminal window, edit the `redis.conf` file. This tutorial uses the
+`nano` editor, but you can substitute your favorite editor. Enter the following:
 
         sudo nano /etc/redis/redis.conf
 
-1. Scroll down to the line that begins with `bind 127.0.0.1` 
+1. Scroll down to the line that begins with `bind 127.0.0.1`. 
 
 1. Replace `127.0.0.1` with `0.0.0.0`:
 
@@ -112,20 +113,24 @@ Follow these steps.
 
    The `bind 0.0.0.0` setting enables Redis to accept connections from any IP address. This is
    a commonly used setting. When bound to `127.0.0.1`, Redis will only accept connections
-   from the local machine running Redis -- meaning your application would have to reside on the
+   from the local machine running Redis, meaning that your application would have to reside on the
    same machine as the Redis server.
    
+   The `bind 0.0.0.0` setting makes your instance publicly accessible. This requires you to add a
+   strong password to protect your instance from unauthorized access and malicious activities. 
+
 1. Scroll down to the line that begins with `# requirepass`.   
 
-1. Uncomment `# requirepass` and add a strong password (see the 'SECURITY' section of the [Redis configuration file example](http://download.redis.io/redis-stable/redis.conf) for details):
+1. Uncomment `# requirepass` and add a strong password.
 
          requirepass [REPLACE_WITH_YOUR_STRONG_PASSWORD]
    
-   The `bind 0.0.0.0` setting you made in step 3 makes your instance publicly accessible. This requires you to add a strong password to protect your instance from unauthorized access and malicious activities. 
-
+   For details, see the "SECURITY" section of the
+   [Redis configuration file example](http://download.redis.io/redis-stable/redis.conf).
+   
 1. Save the file and exit the editor.
 
-1. Restart the database service. In the SSH terminal, enter:
+1. Restart the database service. In the SSH terminal, enter the following:
 
         sudo service redis-server restart
 
@@ -133,13 +138,13 @@ Follow these steps.
 
         ps -f -u redis
 
-   You should now see something like:
+   You should now see something like the following:
 
         yourname@redis-tutorial:~$ ps -f -u redis
         UID        PID  PPID  C STIME TTY          TIME CMD
         redis      950     1  0 21:07 ?        00:00:00 /usr/bin/redis-server 0.0.0.0:6379
 
-Congratulations, Redis will now accept connections from external machines.
+Congratulations! Redis will now accept connections from external machines.
 
 ## Open the network port (optional)
 
@@ -151,16 +156,12 @@ Redis accepts remote connections on TCP port 6379. Follow these steps to add
 a firewall rule that enables traffic on this port.
 
 
-1. In the Cloud Console, navigate to the **Create a firewall rule**
-   page.
-
-    **[Create a firewall rule](https://console.cloud.google.com/networking/firewalls/add)**
+1. In the Cloud Console, go to the
+   [**Create a firewall rule**](https://console.cloud.google.com/networking/firewalls/add) page.
 
 1. In the **Network** field, leave the network as **default**.
 
-1. In the **Name** field, enter:
-
-        redis-tutorial
+1. In the **Name** field, enter `redis-tutorial`.
 
 1. In a separate window, navigate to [ip4.me](http://ip4.me) to get the IPv4 address of your local computer.
 
@@ -168,36 +169,32 @@ a firewall rule that enables traffic on this port.
    Append `/32` to the end of the IPv4 address to format in
    [CIDR notation](https://wikipedia.org/wiki/Classless_Inter-Domain_Routing). For example: `1.2.3.4/32`.
 
-1. In **Allowed protocols and ports**, enter:
-
-        tcp:6379
+1. In **Allowed protocols and ports**, enter `tcp:6379`.
 
 1. Click **Create**.
 
-You are now able to connect to your redis instance from your local machine.
+You are now able to connect to your Redis instance from your local machine.
 
-Note that firewall rules are a global resource, so you'll only need to
-create this rule once for all instances.
+Firewall rules are a global resource, so you'll only need to create this rule once for all instances.
 
 ### Connect using redis-cli
 
 Now you can connect to your Redis database from your computer. This tutorial uses `redis-cli`,
-an officially supported command line tool to interact with a Redis server. Follow these steps.
+an officially supported command-line tool to interact with a Redis server.
 
-1. Install [redis](https://redis.io/topics/quickstart#installing-redis) on your local computer.
+1. Install [Redis](https://redis.io/topics/quickstart#installing-redis) on your local computer.
 
-1. Navigate to the **VM instances** page and find the external IP address of
-your Compute Engine instance in the **External IP** column.
+1. Go to the [**VM instances**](https://console.cloud.google.com/compute/instances) page and find the
+   external IP address of your Compute Engine instance in the **External IP** column.
 
-    **[Open VM instances](https://console.cloud.google.com/compute/instances)**
-
-1. Ping the Redis server. Replace `[REDIS_IPV4_ADDRESS]` with the external IP address from the previous step and `[YOUR_STRONG_PASSWORD]` with the password you defined in step 5 of the **Edit `redis.conf`** section:
+1. Ping the Redis server. Replace `[REDIS_IPV4_ADDRESS]` with the external IP address from the previous step
+   and `[YOUR_STRONG_PASSWORD]` with the password you defined in step 5 of the "Edit `redis.conf`" section:
 
         redis-cli -h [REDIS_IPV4_ADDRESS] -a '[YOUR_STRONG_PASSWORD]' ping
 
 You should receive a response of `PONG` output to the terminal.
 
-Congratulations, you've successfully connected to your Redis server!
+Congratulations! You've successfully connected to your Redis server.
 
 ## Best practices
 
@@ -206,13 +203,13 @@ installation of Redis. In a production environment, it's a good idea to
 employ strategies for high availability, scalability, archiving, backup, load
 balancing, and disaster recovery. For information about disaster recovery
 planning, see
-[How to Design a Disaster Recovery Plan](https://cloud.google.com/solutions/designing-a-disaster-recovery-plan).
+[How to design a disaster recovery plan](https://cloud.google.com/solutions/designing-a-disaster-recovery-plan).
 
 For better performance and data safety, install the database engine on the boot
 disk as this tutorial showed, and then set up the data storage on a separate
 persistent disk.
 
-For machines that have an Internet connection, limit access only to trusted IP ranges.
+For machines that have an internet connection, limit access only to trusted IP ranges.
 
 
 ## Cleaning up
@@ -227,7 +224,7 @@ The easiest way to eliminate billing is to delete the project you created for th
 
 To delete the project:
 
-1. In the Cloud Platform Console, go to the **[Projects](https://console.cloud.google.com/iam-admin/projects)** page.
+1. In the Cloud Console, go to the [**Projects**](https://console.cloud.google.com/iam-admin/projects)** page.
 1. Click the trash can icon to the right of the project name.
 
 **Warning**: Deleting a project has the following consequences:
@@ -240,7 +237,7 @@ You can't reuse the project ID of a deleted project. If you created a custom pro
 
 To delete a Compute Engine instance:
 
-1. In the Cloud Platform Console, go to the **[VM Instances](https://console.cloud.google.com/compute/instances)** page.
+1. In the Cloud Console, go to the [**VM Instances**](https://console.cloud.google.com/compute/instances) page.
 1. Click the checkbox next to your `redis-tutorial` instance.
 1. Click the Delete button at the top of the page to delete the instance.
 
@@ -249,7 +246,7 @@ To delete a Compute Engine instance:
 
 To delete a firewall rule:
 
-1. In the Cloud Platform Console, go to the **[Firewall Rules](https://console.cloud.google.com/networking/firewalls)** page.
+1. In the Cloud Console, go to the [**Firewall Rules**](https://console.cloud.google.com/networking/firewalls) page.
 1. Click the checkbox next to the firewall rule you want to delete.
 1. Click the Delete button at the top of the page to delete the firewall rule.
 

--- a/tutorials/setting-up-redis.md
+++ b/tutorials/setting-up-redis.md
@@ -104,7 +104,7 @@ Follow these steps.
 
         sudo nano /etc/redis/redis.conf
 
-1. Scroll down to the line that begins with `bind 127.0.0.1`
+1. Scroll down to the line that begins with `bind 127.0.0.1` 
 
 1. Replace `127.0.0.1` with `0.0.0.0`:
 
@@ -114,6 +114,14 @@ Follow these steps.
    a commonly used setting. When bound to `127.0.0.1`, Redis will only accept connections
    from the local machine running Redis -- meaning your application would have to reside on the
    same machine as the Redis server.
+   
+1. Scroll down to the line that begins with `# requirepass`.   
+
+1. Uncomment `# requirepass` and add a strong password (see the 'SECURITY' section of the [Redis configuration file example](http://download.redis.io/redis-stable/redis.conf) for details):
+
+         requirepass [REPLACE_WITH_YOUR_STRONG_PASSWORD]
+   
+   The `bind 0.0.0.0` setting you made in step 3 makes your instance publicly accessible. This requires you to add a strong password to protect your instance from unauthorized access and malicious activities. 
 
 1. Save the file and exit the editor.
 
@@ -183,9 +191,9 @@ your Compute Engine instance in the **External IP** column.
 
     **[Open VM instances](https://console.cloud.google.com/compute/instances)**
 
-1. Ping the Redis server. Replace `[REDIS_IPV4_ADDRESS]` with the external IP address from the previous step.
+1. Ping the Redis server. Replace `[REDIS_IPV4_ADDRESS]` with the external IP address from the previous step and `[YOUR_STRONG_PASSWORD]` with the password you defined in step 5 of the **Edit `redis.conf`** section:
 
-        redis-cli -h [REDIS_IPV4_ADDRESS] ping
+        redis-cli -h [REDIS_IPV4_ADDRESS] -a '[YOUR_STRONG_PASSWORD]' ping
 
 You should receive a response of `PONG` output to the terminal.
 


### PR DESCRIPTION
When changing to 'bind 0.0.0.0', the recommendation is to set up a password to protect the instance from unauthorized access. This also means that when pinging the Redis server, this password needs to be specified (it would be good if this latter point could be verified, we were not able to test this).