### PR TITLE
Add krt_prefsrc to the export filter of bird

### DIFF
--- a/tutorials/using-cloud-vpn-with-strongswan/index.md
+++ b/tutorials/using-cloud-vpn-with-strongswan/index.md
@@ -312,7 +312,10 @@ This guide assumes that you have strongSwan already installed. It also assumes a
     protocol kernel {
            learn;
            merge paths on; # For ECMP
-           export all; # Sync all routes to kernel
+           export filter { 
+                  krt_prefsrc = 10.164.0.6; # Internal IP Address of the strongSwan VM. 
+                  accept; # Sync all routes to kernel
+           };
            import all; # Required due to /32 on GCE VMs for the static route below
     }
 


### PR DESCRIPTION
If we don't have `krt_prefsrc` (adds src to routes exported to kernel) testing connectivity from strongSwan VM won't be possible. Packets sent to the VMs on the CloudVPN Side will have `source` address of the VTI interface (which is not routable back for instances behind CloudVPN).
     The `krt_prefsrc` option adds source to learned routes, in that case routes will be origination from strongSwan VM local interface (going then through VTI interface) and will be routable back. 
Summing that up: it makes it possible to access GCE instances (ping/ssh etc) behind CloudVPN from strongSwan VM itself. All the connectivity for the instances routed through strongSwan VM will be still working.  