### PR TITLE
Fix License Agreement links in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,11 +14,9 @@ Please fill out either the individual or corporate Contributor License Agreement
 (CLA).
 
   * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual CLA]
-    (https://developers.google.com/open-source/cla/individual).
+    own the intellectual property, then you'll need to sign an [individual CLA](https://developers.google.com/open-source/cla/individual).
   * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate CLA]
-    (https://developers.google.com/open-source/cla/corporate).
+    then you'll need to sign a [corporate CLA](https://developers.google.com/open-source/cla/corporate).
 
 Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Once we receive it, we'll be able to


### PR DESCRIPTION
There is a bug in CONTRIBUTING.md where the text appears as below instead of clickable text:
- [individual CLA] (https://developers.google.com/open-source/cla/individual)
- [corporate CLA] (https://developers.google.com/open-source/cla/corporate)

This fix makes it such that the text "individual CLA" and "corporate CLA" are clickable and direct to their respective urls