### PR TITLE
fix device configuration with environment variable

### DIFF
--- a/tutorials/cloud-iot-enviro-board-workshop/enviro-device/cloud_config_template.ini
+++ b/tutorials/cloud-iot-enviro-board-workshop/enviro-device/cloud_config_template.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 Enabled = true
-ProjectID = <replace with project id>
+ProjectID = ${PROJECT_ID}
 CloudRegion = europe-west1
 RegistryID = enviro-registry
 DeviceID = enviro-board

--- a/tutorials/cloud-iot-enviro-board-workshop/index.md
+++ b/tutorials/cloud-iot-enviro-board-workshop/index.md
@@ -89,7 +89,7 @@ In the Raspberry Pi shell, run the following command to download the necessary s
 
     mkdir -p "$HOME"/enviro-board
     cd "$HOME"/enviro-board
-    wget https://raw.githubusercontent.com/GoogleCloudPlatform/community/master/tutorials/cloud-iot-enviro-board-workshop/enviro-device/cloud_config.ini
+    wget https://raw.githubusercontent.com/GoogleCloudPlatform/community/master/tutorials/cloud-iot-enviro-board-workshop/enviro-device/cloud_config_template.ini
     wget https://raw.githubusercontent.com/GoogleCloudPlatform/community/master/tutorials/cloud-iot-enviro-board-workshop/enviro-device/core.py
     wget https://raw.githubusercontent.com/GoogleCloudPlatform/community/master/tutorials/cloud-iot-enviro-board-workshop/enviro-device/enviro_demo.py
 
@@ -190,10 +190,9 @@ Later, you use the subscription to get the messages.
 
         export PROJECT_ID=your-gcp-project-id
 
-1.  In the Raspberry Pi shell, set your GCP project ID in the device application configuration file with this command,
-    replacing `[REPLACE_THIS_WITH_YOUR_PROJECT_ID_VALUE]` with your project ID value:
+1.  In the Raspberry Pi shell, set your GCP project ID in the device application configuration file with this command:
 
-        sed -i -e 's/[REPLACE_THIS_WITH_YOUR_PROJECT_ID_VALUE]/'"${PROJECT_ID}"'/g' $HOME/enviro-board/cloud_config.ini
+        envsubst < $HOME/enviro-board/cloud_config_template.ini > $HOME/enviro-board/cloud_config.ini
 
 ### Download the CA certificate
 


### PR DESCRIPTION
The current set device configuration step is broken. This fixes the issue and makes the environment variable substitution easier.

