### PR TITLE
Removed legacy health check configuration.

### DIFF
--- a/tutorials/deploy-grails-to-google-cloud/index.md
+++ b/tutorials/deploy-grails-to-google-cloud/index.md
@@ -240,9 +240,6 @@ runtime_config:
     jdk: openjdk8
     server: jetty9
 
-health_check:
-    enable_health_check: False
-
 resources:
     cpu: 1
     memory_gb: 2.3


### PR DESCRIPTION
Before removing it the following error was thrown:

`ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: Legacy health checks are no longer supported for the App Engine Flexible environment. Please remove the 'health_check' section from your app.yaml and configure updated health checks. For instructions on migrating to split health checks see https://cloud.google.com/appengine/docs/flexible/java/migrating-to-split-health-checks`