### PR TITLE
removed legacy health check

### DIFF
--- a/tutorials/appengine-ruby-rails-activejob-pubsub.md
+++ b/tutorials/appengine-ruby-rails-activejob-pubsub.md
@@ -193,9 +193,6 @@ of your web instances at the cost of potentially using more resources.
         env_variables:
           SECRET_KEY_BASE: [SECRET_KEY]
 
-        health_check:
-          enable_health_check: False
-
         # Optional scaling configuration
         manual_scaling:
           instances: 1


### PR DESCRIPTION
If this check stays in place, then the app can't be deployed:

https://cloud.google.com/appengine/docs/flexible/ruby/migrating-to-split-health-checks