### PR TITLE
copy-edit, making steps and code not run into paragraphs

### DIFF
--- a/tutorials/cloud-spanner-commit-timestamp-change-log/index.md
+++ b/tutorials/cloud-spanner-commit-timestamp-change-log/index.md
@@ -1,6 +1,6 @@
 ---
-title: Using Cloud Spanner's Commit Timestamp Feature to Create a Change Log with Go
-description: Learn how to use Cloud Spanner's commit timestamp feature to create a change log.
+title: Using Cloud Spanner commit timestamps to create a change log with Go
+description: Learn how to use Cloud Spanner commit timestamps to create a change log.
 author: jsimonweb
 tags: Cloud Spanner, Go
 date_published: 2018-06-06
@@ -9,29 +9,31 @@ date_published: 2018-06-06
 When was that record changed? Use Cloud Spanner to know.
 
 If you have a large database with lots of transactions that change records, it can be a challenge to know
-which records changed most recently. Cloud Spanner's commit timestamp feature makes this easy.
+which records changed most recently. Cloud Spanner commit timestamps make this easy.
 
-This tutorial describes how to use the Cloud Spanner commit timestamp feature to track the date and time of when changes are made to your database records.
+This tutorial describes how to use Cloud Spanner commit timestamps to track the dates and times of when changes are made to
+your database records.
+
 This tutorial includes two approaches to using commit timestamps:
 
 * Include a commit timestamp column when you create your table.
-* Create a companion History table when you create your table.
+* Create a companion history table when you create your table.
 
 Here are the key points:
 
-* Use Spanner's commit timestamp feature to simplify the tracking of changes to your database.
+* Use Spanner commit timestamps to simplify the tracking of changes to your database.
 * If you want to track only when records change in a particular table, create the table with a commit timestamp column.
-* If you want to keep a log of how records change over time, create an additional History table
-  that includes a commit timestamp column. Then use transactions to update the History table when records are
+* If you want to keep a log of how records change over time, create an additional history table
+  that includes a commit timestamp column. Then use transactions to update the history table when records are
   inserted or updated.
-  
-The remainder of this article provides the details you need.
 
 ## Include a commit timestamp column when you create your table
 
 The simplest way to incorporate timestamps into your database is to include a commit timestamp column
-when you create your table. Below is a SQL statement that will create a Spanner table that includes a timestamp column named **Timestamp**. The extra
-options attribute "OPTIONS(allow_commit_timestamp=true)" makes **Timestamp** a commit timestamp column and enables it to be auto-populated with the exact transaction timestamp for INSERT and UPDATE operations on a given table row.
+when you create your table. Below is an SQL statement that creates a Spanner table that includes a
+timestamp column named `Timestamp`. The extra options attribute `OPTIONS(allow_commit_timestamp=true)`
+makes `Timestamp` a commit timestamp column and enables it to be auto-populated with the exact transaction
+timestamp for INSERT and UPDATE operations on a given table row.
 
 ```sql
 CREATE TABLE DocumentsWithTimestamp(
@@ -41,20 +43,21 @@ CREATE TABLE DocumentsWithTimestamp(
   Contents STRING(MAX) NOT NULL
 ) PRIMARY KEY(UserId, DocumentId)
 ```
-You can use this SQL Statement to create a documents table named **DocumentsWithTimestamp**
-using the Spanner page in the GCP console:
-1.  Go to the [**Spanner** page](https://console.cloud.google.com/spanner) in the Cloud Platform Console.
-1.  Create a new Cloud Spanner instance named **spanner-sample**.
-1.  Select the **Create Database** button.
-1.  Enter the Database name as **sample-db** and click  the **Continue** button.
-1.  Click the **Edit as text** option to activate it and enter the SQL statement above as the DDL statement:
 
-![Spanner: Create Database](https://storage.googleapis.com/gcp-community/tutorials/cloud-spanner-commit-timestamp-change-log/spanner-create-documents-table.png)
+You can use this SQL statement to create a documents table named `DocumentsWithTimestamp`
+using the Spanner page in the Cloud Console:
+
+1.  Go to the [**Spanner** page](https://console.cloud.google.com/spanner) in the Cloud Console.
+1.  Create a new Cloud Spanner instance named `spanner-sample`.
+1.  Select the **Create Database** button.
+1.  Enter the Database name as `sample-db` and click the **Continue** button.
+1.  Click the **Edit as text** option to activate it and enter the SQL statement above as the DDL statement
 
 When inserting records, use a method like the following Go sample code to
 insert a timestamp in the commit timestamp column. This code snippet inserts the
-**spanner.CommitTimestamp** constant which will populate the **Timestamp** column
-with the exact timestamp of when each record was inserted.
+`spanner.CommitTimestamp` constant, which populates the `Timestamp` column
+with the exact timestamp of when each record was inserted:
+
 ```go
 func writeToDocumentsTable(ctx context.Context, w io.Writer, client *spanner.Client) error {
 	documentsColumns := []string{"UserId", "DocumentId", "Timestamp", "Contents"}
@@ -70,7 +73,7 @@ func writeToDocumentsTable(ctx context.Context, w io.Writer, client *spanner.Cli
 
 When updating records, use a method like the following Go sample code to update the commit timestamp column.
 This code updates five records and uses the **spanner.CommitTimestamp** constant which populates the **Timestamp** column
-with the exact timestamp of when each record was updated.
+with the exact timestamp of when each record was updated:
 
 ```go
 func updateDocumentsTable(ctx context.Context, w io.Writer, client *spanner.Client) error {
@@ -90,8 +93,9 @@ func updateDocumentsTable(ctx context.Context, w io.Writer, client *spanner.Clie
 	return err
 }
 ```
-If you want to find the last five records that were updated in the table,
-the commit timestamp column allows you to use a query like the following.
+
+If you want to find the last 5 records that were updated in the table,
+the commit timestamp column allows you to use a query like the following:
 
 ```sql
 SELECT UserId, DocumentId, Timestamp, Contents
@@ -99,21 +103,18 @@ FROM DocumentsWithTimestamp
 ORDER BY Timestamp DESC Limit 5
 ```
 
-This query returns the last 5 rows that were updated in order from newest to oldest.
+This query returns the last 5 rows that were updated, in order from newest to oldest.
 
-You can run this SQL Statement to query the **DocumentsWithTimestamp**
-table from the [**Cloud Spanner**](https://console.cloud.google.com/spanner) page in the GCP Console:
+You can run this SQL statement to query the `DocumentsWithTimestamp`
+table from the [**Cloud Spanner**](https://console.cloud.google.com/spanner) page in the Cloud Console.
 
-
-![Spanner Query Documents Table](https://storage.googleapis.com/gcp-community/tutorials/cloud-spanner-commit-timestamp-change-log/spanner-query-documents-table.png)
-
-## Create a companion History table when you create your table
+## Create a companion history table when you create your table
 
 As an alternative to adding timestamp columns to your table, if you would like to more
-thoroughly track changes to your records over time, you can create a companion History table
+thoroughly track changes to your records over time, you can create a companion history table
 when you create your table.
 
-The following SQL statements create two tables, a **Documents** table and a **DocumentHistory** table.
+The following SQL statements create two tables: `Documents` and `DocumentHistory`:
 
 ```sql
 CREATE TABLE Documents(
@@ -129,14 +130,16 @@ CREATE TABLE DocumentHistory(
   PreviousContents STRING(MAX)
 ) PRIMARY KEY(UserId, DocumentId, Timestamp), INTERLEAVE IN PARENT Documents ON DELETE NO ACTION
 ```
-The **DocumentHistory** table will store a transaction timestamp along with a copy
-of the **Documents** table's **Contents** column as it changes.
-The **DocumentHistory** table's **PreviousContents** column will initially be populated with the original value
-inserted into the **Documents** table's **Contents** column. When a transaction updates a given row in the
-**Documents** table, before the the **Contents** column's value is changed, its current value is first saved in the **DocumentHistory**
-table's **PreviousContents** column along with a transaction timestamp in the **Timestamp** column.
 
-This snippet of Go code inserts 5 records into each of the tables as a transaction with commit timestamps:
+The `DocumentHistory` table stores a transaction timestamp along with a copy
+of the `Documents` table's `Contents` column as it changes.
+
+The `DocumentHistory` table's `PreviousContents` column is initially populated with the original value
+inserted into the `Documents` table's `Contents` column. When a transaction updates a given row in the
+`Documents` table before the the `Contents` column's value is changed, its current value is first saved in the 
+`DocumentHistory` table's `PreviousContents` column along with a transaction timestamp in the `Timestamp` column.
+
+The following Go code inserts 5 records into each of the tables as a transaction with commit timestamps:
 
 ```go
 func writeWithHistory(ctx context.Context, w io.Writer, client *spanner.Client) error {
@@ -171,7 +174,7 @@ func writeWithHistory(ctx context.Context, w io.Writer, client *spanner.Client) 
 }
 ```
 
-This snippet of Go code updates 3 records in each table as a transaction with commit timestamps:
+The following Go code updates 3 records in each table as a transaction with commit timestamps:
 
 ```go
 func updateWithHistory(ctx context.Context, w io.Writer, client *spanner.Client) error {
@@ -239,17 +242,10 @@ ON dh.UserId = d.UserId AND dh.DocumentId = d.DocumentId
 ORDER BY dh.Timestamp DESC LIMIT 3
 ```
 
-You can run this SQL Statement to query the **Documents** and **DocumentHistory**
-tables from the [**Cloud Spanner**](https://console.cloud.google.com/spanner) page in the GCP Console:
+You can run this SQL statement to query the `Documents` and `DocumentHistory`
+tables from the [**Cloud Spanner**](https://console.cloud.google.com/spanner) page in the Cloud Console.
 
+## Next steps
 
-![Spanner Query Documents Table](https://storage.googleapis.com/gcp-community/tutorials/cloud-spanner-commit-timestamp-change-log/spanner-query-document-history-table.png)
-
-
-## Next Steps
-
-* See [the runnable code sample][1] which contains the code snippets included in this article.
-* See [the Cloud Spanner commit timestamp documentation][2]. 
-
-[1]: https://github.com/GoogleCloudPlatform/golang-samples/blob/master/spanner/spanner_snippets/snippet.go
-[2]: https://cloud.google.com/spanner/docs/commit-timestamp
+* See [the runnable code sample](https://github.com/GoogleCloudPlatform/golang-samples/blob/master/spanner/spanner_snippets/snippet.go), which contains the code snippets included in this article.
+* See [the Cloud Spanner commit timestamp documentation](https://cloud.google.com/spanner/docs/commit-timestamp).


### PR DESCRIPTION
copy-edit, branding fixes, and making steps and code not run into paragraphs