### PR TITLE
Fix typo sample command under "Execute the script"

### DIFF
--- a/tutorials/dlp-to-datacatalog-tags/index.md
+++ b/tutorials/dlp-to-datacatalog-tags/index.md
@@ -131,7 +131,7 @@ mvn clean package -DskipTests
 ### Execute the script
 
 ```
-java -cp target/dlp-datacatalog-tags-0.1-jar-with-dependencies.jar com.example.dlp.DlpDataCatalogTagsTutorial \
+java -cp target/dlp-to-datacatalog-tags-0.1-jar-with-dependencies.jar com.example.dlp.DlpDataCatalogTagsTutorial \
 -dbType "bigquery" \
 -limitMax 1000 \
 -dbName research2 \


### PR DESCRIPTION
Fixes typo in the example command line under "Execute the script"