### PR TITLE
update for errors with alpine and py cryptography

### DIFF
--- a/tutorials/kube-mqtt/refresher-container/Dockerfile
+++ b/tutorials/kube-mqtt/refresher-container/Dockerfile
@@ -1,18 +1,9 @@
-FROM python:3.7-alpine as base
-FROM base as builder
+FROM python:3.7
 RUN mkdir /install
 WORKDIR /install
-RUN apk add --no-cache \
-        libressl-dev \
-        musl-dev \
-        libffi-dev \
-        build-base \
-        openssl-dev
 COPY requirements.txt /requirements.txt
-RUN pip install --install-option="--prefix=/install" -r /requirements.txt
-FROM base
-RUN apk add --update bash && rm -rf /var/cache/apk/*
-COPY --from=builder /install /usr/local
+RUN pip install -U pip
+RUN pip install -r /requirements.txt
 COPY src /app
 WORKDIR /app
 CMD ["/usr/local/bin/python", "run_bridge.py"]

--- a/tutorials/kube-mqtt/refresher-container/requirements.txt
+++ b/tutorials/kube-mqtt/refresher-container/requirements.txt
@@ -1,3 +1,3 @@
-cryptography==2.7
+cryptography==2.9.2
 PyJWT==1.7.1
 psutil==5.6.3


### PR DESCRIPTION
There are issues getting the cryptography library to build in updated base alpine images - switching to standard python docker image