### PR TITLE
When updating a fingerprint, it was not removing the : from the filen…

### DIFF
--- a/tutorials/gcp-cos-basic-fim/scan.sh
+++ b/tutorials/gcp-cos-basic-fim/scan.sh
@@ -122,6 +122,7 @@ if [ -f "$FINGERPRINTS" ];then
     cp $FINGERPRINTSTMP $FINGERPRINTS
     chmod 600 $FINGERPRINTS 2> /dev/null
     cat $FAILEDFILES \
+    | awk -F ":" '{ print $1 }' \
     | xargs sha256sum 2>$ERRFILE \
     | tee -a $FINGERPRINTS $LOGFILE
     rm $FAILEDFILES


### PR DESCRIPTION
…ame, and was also passing the FAILED as a parameter
The result is the file got removed from the .base file, and did not get checked again.