### PR TITLE
Proposed change to the "View the cla" link.

### DIFF
--- a/tutorials/write.md
+++ b/tutorials/write.md
@@ -26,7 +26,7 @@ To submit a tutorial:
 
 1.  Accept the Contributor License Agreement (CLA):
 
-    [**View the CLA**](#contributor-license-agreements)
+    [**View the CLA**][contributor-license-agreements]
 
 1.  Read the style guide before preparing your submission:
 
@@ -81,3 +81,4 @@ accept your pull requests.
 [pr]: https://help.github.com/articles/using-pull-requests/
 [in_cla]: https://developers.google.com/open-source/cla/individual
 [corp_cla]: https://developers.google.com/open-source/cla/corporate
+[contributor-license-agreements]: https://cla.developers.google.com/about


### PR DESCRIPTION
I know this link is meant to reference the Contributor license agreements, but for some reason it doesn't seem to work on the google tutorials page. Which leave the user trying to click and wondering why it doesn't work. Would be much better to put a link to the cla about page, as it is well explained and easy to navigate between individual and corporate CLAs.