### PR TITLE
Add link to central Terraform docs.

### DIFF
--- a/tutorials/deploy-ha-vpn-with-terraform/index.md
+++ b/tutorials/deploy-ha-vpn-with-terraform/index.md
@@ -16,7 +16,7 @@ configuration on Google Cloud Platform (GCP).
 
 ## Before you begin
 
-*   This guide assumes that you are familiar with [Terraform](https://www.terraform.io/). Instructions provided in this guide
+*   This guide assumes that you are familiar with [Terraform](https://cloud.google.com/docs/terraform). Instructions provided in this guide
     are based on the GCP envrionment depicted in the
     [HA VPN interop guides](https://cloud.google.com/vpn/docs/how-to/interop-guides) and are only for testing purposes.
 

--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -15,7 +15,7 @@ other APIs, or add a datastore. I'm able to iterate very quickly with feedback
 at each step of the process. To help get through those first set up steps I've
 written this tutorial to cover the following:
 
-* Using Terraform to create a VM in Google Cloud
+* Using [Terraform](https://cloud.google.com/docs/terraform) to create a VM in Google Cloud
 * Starting a basic Python Flask server
 
 ### Before you begin

--- a/tutorials/managing-gcp-projects-with-terraform/index.md
+++ b/tutorials/managing-gcp-projects-with-terraform/index.md
@@ -8,8 +8,8 @@ date_published: 2017-06-19
 
 Dan Isla | Google Cloud Solution Architect | Google
 
-This tutorial demonstrates how to create and manage projects on Google Cloud with Terraform. With Terraform, many of your 
-resources such as projects, IAM policies, networks, Compute Engine instances, and Kubernetes Engine clusters can be managed,
+This tutorial demonstrates how to create and manage projects on [Google Cloud with Terraform](https://cloud.google.com/docs/terraform).
+With Terraform, many of your resources such as projects, IAM policies, networks, Compute Engine instances, and Kubernetes Engine clusters can be managed,
 versioned, and easily recreated for your organization or teams. The state that Terraform generates is saved to Cloud Storage
 for persistence.
 

--- a/tutorials/modular-load-balancing-with-terraform/index.md
+++ b/tutorials/modular-load-balancing-with-terraform/index.md
@@ -10,7 +10,7 @@ Dan Isla | Google Cloud Solution Architect | Google
 
 Load balancing on Google Cloud Platform (GCP) is different from other cloud providers. The primary difference is that Google uses forwarding rules instead of routing instances. These forwarding rules are combined with backend services, target pools, URL maps and target proxies to construct a functional load balancer across multiple regions and instance groups.
 
-[Terraform](https://www.terraform.io) is an open source infrastructure management tool that can greatly simplify the provisioning of load balancers on GCP by using modules.
+[Terraform](https://cloud.google.com/docs/terraform) is an open source infrastructure management tool that can greatly simplify the provisioning of load balancers on GCP by using modules.
 
 This tutorial will demonstrate how to use the GCP Terraform modules for load balancing in a variety of scenarios that you can  build into your own projects.
 


### PR DESCRIPTION
Link to the GCP with Terraform docs for easier discoverability/details: https://cloud.google.com/docs/terraform

This is a new page which we want to promote as the central hub for Terraform + GCP docs.