### PR TITLE
Add caveat for Terraform version used

### DIFF
--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -31,6 +31,9 @@ Have the following tools locally:
 * [An existing SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
 * [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 
+This tutorial is written using Terraform 0.12 syntax, if you are using a
+different version of Terraform some of the syntax will be slightly different.
+
 ## Create a Google Cloud project
 
 A default project is often set up by default for new accounts, but you

--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -31,8 +31,8 @@ Have the following tools locally:
 * [An existing SSH key](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
 * [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 
-This tutorial is written using Terraform 0.12 syntax, if you are using a
-different version of Terraform some of the syntax will be slightly different.
+This tutorial is written using Terraform 0.12 syntax. If you're using a
+different version of Terraform, some of the syntax will be slightly different.
 
 ## Create a Google Cloud project
 


### PR DESCRIPTION
This is meant to help users that have different versions of Terraform as the HCL syntax evolved significantly in the 0.12 release.

fixes https://github.com/GoogleCloudPlatform/community/issues/1234