### PR TITLE
Edit - Community Tutorial: inspect BigQuery with DLP and integrate with Data Catalog

### DIFF
--- a/tutorials/dlp-to-datacatalog-tags/src/main/java/com/example/dlp/DlpDataCatalogTagsTutorial.java
+++ b/tutorials/dlp-to-datacatalog-tags/src/main/java/com/example/dlp/DlpDataCatalogTagsTutorial.java
@@ -546,8 +546,9 @@ public class DlpDataCatalogTagsTutorial {
       }
       java.util.Hashtable<String, Integer> tempCol = columnHash.get(columnName);
 
-      if (getTopInfoTypeMin(tempCol) >= minThreshold) {
+      int returnedThreshold = getTopInfoTypeMin(tempCol);
 
+      if (returnedThreshold >= minThreshold) {
         try {
           String topInfoType = getTopInfoType(tempCol);
           String tagTemplateID = "dlp_tag_template_v2_column";
@@ -773,10 +774,25 @@ public class DlpDataCatalogTagsTutorial {
           System.out.println("Error writing findings to DC ");
           err.printStackTrace();
         }
+      } else {
+        if (VERBOSE_OUTPUT) {
+          System.out.println(">> Findings for ["
+              + columnName + "] has threshold " + returnedThreshold
+              + " when minimum threshold is " + minThreshold
+          );
+        }
       }
     }
     try {
-      batchRequest.execute();
+      if (batchRequest.size() > 0) {
+        batchRequest.execute();
+      } else {
+        if (VERBOSE_OUTPUT) {
+          System.out.println(">> Not creating Data Catalog Tags for "
+              + "[" + dbName + "]" + "[" + theTable + "]"
+          );
+        }
+      }
     } catch (IOException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
Some updates on this tutorial:

1 - Added a fix to the code
When all DLP findings for a given Table was below the minimum threshold set at runtime, it would create a empty batch client call, generating an error message.

2 - Improved logging to help users troubleshoot this scenario.
Example:
`
>> Column [city] has findings
>> Findings for [city] has threshold 7 when minimum threshold is 100
>> Column [county] has findings
>> Findings for [county] has threshold 11 when minimum threshold is 100
>> Column [first_name] has findings
>> Findings for [first_name] has threshold 61 when minimum threshold is 100
>> Column [phone] has findings
>> Findings for [phone] has threshold 99 when minimum threshold is 100
>> Column [email] has findings
>> Findings for [email] has threshold 99 when minimum threshold is 100
>> Column [address] has findings
>> Findings for [address] has threshold 5 when minimum threshold is 100
>> Column [phone1] has findings
>> Findings for [phone1] has threshold 99 when minimum threshold is 100
>> Column [last_name] has findings
>> Findings for [last_name] has threshold 8 when minimum threshold is 100
>> Column [company_name] has findings
>> Findings for [company_name] has threshold 37 when minimum threshold is 100
>> Not creating Data Catalog Tags for [dlp_error_test][100_c]
>> Runnable done for: 100_c on thread: pool-3-thread-1
>> Runnable started for: 100_r on thread: pool-3-thread-1
`

fixes #1345 

Thanks