### PR TITLE
Add tutorial for cloud function with cloud build

### DIFF
--- a/tutorials/cloud-functions-cloudbuild/cloudbuild.yaml
+++ b/tutorials/cloud-functions-cloudbuild/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+  - name: 'mirror.gcr.io/library/golang'
+    args: ['go', 'version']
+  - name: 'mirror.gcr.io/library/golang'
+    args: ['go', 'test']
+    dir: 'code'
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args: ['functions', 'deploy', 'cloudfunction01', '--trigger-http', '--runtime', 'go113', '--entry-point', 'HelloWorld']
+    dir: 'code'
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args: ['functions', 'add-iam-policy-binding', 'cloudfunction01', '--member', 'allUsers', '--role', 'roles/cloudfunctions.invoker']

--- a/tutorials/cloud-functions-cloudbuild/code/function.go
+++ b/tutorials/cloud-functions-cloudbuild/code/function.go
@@ -1,0 +1,26 @@
+// Package p contains an HTTP Cloud Function.
+package p
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+)
+
+// HelloWorld prints the JSON encoded "message" field in the body
+// of the request or "Hello World!" if there isn't one.
+func HelloWorld(w http.ResponseWriter, r *http.Request) {
+	var d struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		fmt.Fprint(w, "Hello World!")
+		return
+	}
+	if d.Message == "" {
+		fmt.Fprint(w, "Hello World!")
+		return
+	}
+	fmt.Fprint(w, html.EscapeString(d.Message))
+}

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -10,7 +10,7 @@ Niklas Rosencrantz | DevOps/SRE
 
 ## Introduction
 
-This tutorial demonstrates how to create a Cloud Function with [Cloud Build](https://cloud.google.com/cloud-build).
+This tutorial demonstrates how to create and deploy a Cloud Function with [Cloud Build](https://cloud.google.com/cloud-build).
 
 ## Objectives
 
@@ -27,20 +27,25 @@ This tutorial demonstrates how to create a Cloud Function with [Cloud Build](htt
         gcloud services enable cloudfunctions.googleapis.com
 
 1.  Add the [Cloud Build GitHub app](https://github.com/marketplace/google-cloud-build) to your GitHub account and repository. 
-1.  Create the directory and file structure in the GitHub repository. You can copy the file tree from this tutorial or use your own names. It should be enough with a file named ´cloudbuild.yaml´ in the root directory and the code for the cloud function in a separate directory. In this case it will look similar to the following file tree:
+1.  Create the directory and file structure in the GitHub repository.
+
+    You can use the file tree from the
+    [source for this tutorial](https://github.com/GoogleCloudPlatform/community/tree/master/tutorials/cloud-functions-cloudbuild/) as a starting point. 
+    
+    Put a file named `cloudbuild.yaml` in the root directory and the code for the Cloud Function in a separate directory, as in the following file tree:
 
         │   .gitignore
         │   cloudbuild.yaml
         └───code
                 function.go
 
+## Connect the repository with Cloud Build
 
-1.  Connect the repository with Cloud Build from the Cloud Console. This is done by navigating to [Cloud Build](https://console.cloud.google.com/cloud-build), choose the meny item "triggers" and press the choice "Connect repository" (it also lets you choose a Bitbucket repository at this point as a beta feature). Then you can create a push trigger so that Cloud Build will run when you push to the master branch. 
+1.  In the Cloud Console, go to the [Cloud Build](https://console.cloud.google.com/cloud-build) page.
+1.  Choose **Triggers**.
+1.  Click **Connect repository**.
+1.  Create a push trigger so that Cloud Build will run when you push to the master branch. 
 
-### Cloud Build 
+After you have connected the repository with Cloud Build, Cloud Build will run, build, test, and deploy your Cloud Function each time you push to the repository.
 
-Now Cloud Build will run, build, test, and deploy your Cloud Function every time you push to the repository. You will be able to view a [list](https://console.cloud.google.com/cloud-build/builds) in Cloud Build of your builds. You can view the details of your deployment and see what is the url, for example:
-
-        entryPoint: HelloWorld
-        httpsTrigger:
-          url:   url: https://us-central1-myprojectname.cloudfunctions.net/cloudfunction01
+You can view a list of your builds on the [Cloud Builds page of the Cloud Console](https://console.cloud.google.com/cloud-build/builds).

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -29,12 +29,12 @@ This tutorial demonstrates how to create a cloud function from cloudbuild
         cloudfunctions.googleapis.com \
 
     
-1.  Create the directory and file structure in the GitHub repository
-1.  Create the directory and file structure in the GitHub repository
-1.  Connect the repository with Cloud Build from the GCP project console
+1.  Add [Cloud Build GitHub App](https://github.com/marketplace/google-cloud-build) to your GitHub account and repository. 
+1.  Create the directory and file structure in the GitHub repository.
+1.  Connect the repository with Cloud Build from the GCP project console.
 
 ### Cloud Build 
 
-Now the cloud build will run, build and test your project every time you push to the repository
+Now the cloud build will run, build, test and deploy your cloud function every time you push to the repository.
 
 [console]: https://console.cloud.google.com/

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -10,7 +10,7 @@ Niklas Rosencrantz | DevOps/SRE
 
 ## Introduction
 
-This tutorial demonstrates how to create a cloud function from cloudbuild
+This tutorial demonstrates how to create a cloud function from [GCP Cloud Build](https://cloud.google.com/cloud-build).
 
 ## Objectives
 

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -3,7 +3,7 @@ title: Deploy a Cloud Function with Cloud Build
 description: Use Cloud Build to continuously deploy a Cloud Function.
 author: montao
 tags: Cloud Functions, GitHub, GoLang, continuous integration, continuous delivery, continuous deployment
-date_published: 2020-07-31
+date_published: 2020-07-29
 ---
 
 Niklas Rosencrantz | DevOps/SRE

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -2,7 +2,7 @@
 title: Cloud function with cloudbuild and continuous delivery
 description: Use cloudbuild to deploy to cloud functions.
 author: montao
-tags: Cloud Functions, Cloud Build, GoLang, CI/CD
+tags: Cloud Functions, Cloud Build, GitHub, GoLang, Continuous Integration, Continuous Delivery
 date_published: 2020-07-25
 ---
 

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -27,9 +27,20 @@ This tutorial demonstrates how to create a Cloud Function with [Cloud Build](htt
         gcloud services enable cloudfunctions.googleapis.com
 
 1.  Add the [Cloud Build GitHub app](https://github.com/marketplace/google-cloud-build) to your GitHub account and repository. 
-1.  Create the directory and file structure in the GitHub repository.
-1.  Connect the repository with Cloud Build from the Cloud Console.
+1.  Create the directory and file structure in the GitHub repository. You can copy the file tree from this tutorial or use your own names. It should be enough with a file named ´cloudbuild.yaml´ in the root directory and the code for the cloud function in a separate directory. In this case it will look similar to the following file tree:
+
+        │   .gitignore
+        │   cloudbuild.yaml
+        └───code
+                function.go
+
+
+1.  Connect the repository with Cloud Build from the Cloud Console. This is done by navigating to [Cloud Build](https://console.cloud.google.com/cloud-build), choose the meny item "triggers" and press the choice "Connect repository" (it also lets you choose a Bitbucket repository at this point as a beta feature). Then you can create a push trigger so that Cloud Build will run when you push to the master branch. 
 
 ### Cloud Build 
 
-Now Cloud Build will run, build, test, and deploy your Cloud Function every time you push to the repository.
+Now Cloud Build will run, build, test, and deploy your Cloud Function every time you push to the repository. You will be able to view a [list](https://console.cloud.google.com/cloud-build/builds) in Cloud Build of your builds. You can view the details of your deployment and see what is the url, for example:
+
+        entryPoint: HelloWorld
+        httpsTrigger:
+          url:   url: https://us-central1-myprojectname.cloudfunctions.net/cloudfunction01

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -15,7 +15,7 @@ This tutorial demonstrates how to create and deploy a Cloud Function with [Cloud
 ## Objectives
 
 * Use Cloud Build to deploy a Cloud Function.
-* Use GoLang to process incoming HTTP requests.
+* Use code written in the Go programming language to process incoming HTTP requests.
 
 ## Set up your environment
 

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -1,40 +1,35 @@
 ---
-title: Cloud function with cloudbuild and continuous delivery
-description: Use cloudbuild to deploy to cloud functions.
+title: Deploy a Cloud Function with Cloud Build
+description: Use Cloud Build to continuously deploy a Cloud Function.
 author: montao
-tags: Cloud Functions, Cloud Build, GitHub, GoLang, Continuous Integration, Continuous Delivery
-date_published: 2020-07-25
+tags: Cloud Functions, GitHub, GoLang, continuous integration, continuous delivery, continuous deployment
+date_published: 2020-07-31
 ---
 
 Niklas Rosencrantz | DevOps/SRE
 
 ## Introduction
 
-This tutorial demonstrates how to create a cloud function from [GCP Cloud Build](https://cloud.google.com/cloud-build).
+This tutorial demonstrates how to create a Cloud Function with [Cloud Build](https://cloud.google.com/cloud-build).
 
 ## Objectives
 
-* Use [GCP Cloud Build](https://cloud.google.com/cloud-build) to deploy a cloud function.
+* Use Cloud Build to deploy a Cloud Function.
 * Use GoLang to process incoming HTTP requests.
 
 ## Set up your environment
 
-1.  Create a project in the [GCP Console][console].
-    
+1.  Create a project in the [Cloud Console](https://console.cloud.google.com/).
 1.  [Enable billing for your project](https://cloud.google.com/billing/docs/how-to/modify-project).
-1.  Create a GitHub repository for your project
-1.  Enable APIs:
+1.  Create a GitHub repository for your project.
+1.  Enable the Cloud Functions API:
 
-        gcloud services enable \
-        cloudfunctions.googleapis.com \
+        gcloud services enable cloudfunctions.googleapis.com
 
-    
-1.  Add [Cloud Build GitHub App](https://github.com/marketplace/google-cloud-build) to your GitHub account and repository. 
+1.  Add the [Cloud Build GitHub app](https://github.com/marketplace/google-cloud-build) to your GitHub account and repository. 
 1.  Create the directory and file structure in the GitHub repository.
-1.  Connect the repository with Cloud Build from the GCP project console.
+1.  Connect the repository with Cloud Build from the Cloud Console.
 
 ### Cloud Build 
 
-Now the cloud build will run, build, test and deploy your cloud function every time you push to the repository.
-
-[console]: https://console.cloud.google.com/
+Now Cloud Build will run, build, test, and deploy your Cloud Function every time you push to the repository.

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -15,7 +15,7 @@ This tutorial demonstrates how to create a cloud function from [GCP Cloud Build]
 ## Objectives
 
 * Use [GCP Cloud Build](https://cloud.google.com/cloud-build) to deploy a cloud function.
-* Use GoLang to process incoming HTTP request
+* Use GoLang to process incoming HTTP requests.
 
 ## Set up your environment
 

--- a/tutorials/cloud-functions-cloudbuild/index.md
+++ b/tutorials/cloud-functions-cloudbuild/index.md
@@ -1,0 +1,40 @@
+---
+title: Cloud function with cloudbuild and continuous delivery
+description: Use cloudbuild to deploy to cloud functions.
+author: montao
+tags: Cloud Functions, Cloud Build, GoLang, CI/CD
+date_published: 2020-07-25
+---
+
+Niklas Rosencrantz | DevOps/SRE
+
+## Introduction
+
+This tutorial demonstrates how to create a cloud function from cloudbuild
+
+## Objectives
+
+* Use [GCP Cloud Build](https://cloud.google.com/cloud-build) to deploy a cloud function.
+* Use GoLang to process incoming HTTP request
+
+## Set up your environment
+
+1.  Create a project in the [GCP Console][console].
+    
+1.  [Enable billing for your project](https://cloud.google.com/billing/docs/how-to/modify-project).
+1.  Create a GitHub repository for your project
+1.  Enable APIs:
+
+        gcloud services enable \
+        cloudfunctions.googleapis.com \
+
+    
+1.  Create the directory and file structure in the GitHub repository
+1.  Create the directory and file structure in the GitHub repository
+1.  Connect the repository with Cloud Build from the GCP project console
+
+### Cloud Build 
+
+Now the cloud build will run, build and test your project every time you push to the repository
+
+[console]: https://console.cloud.google.com/


### PR DESCRIPTION
I wrote a tutorial how to use cloud build to deploy a cloud function to GCP. It deploys a public HTTP endpoint using cloud build and CI/CD. My original repository is (or was) at this link https://github.com/montao/faas-cicd

Feel free to ask me anything about it if there are any questions. 