### PR TITLE
Edit - Community Tutorial: inspect BigQuery with DLP and integrate with Data Catalog

### DIFF
--- a/tutorials/dlp-to-datacatalog-tags/src/main/java/com/example/dlp/DlpDataCatalogTagsTutorial.java
+++ b/tutorials/dlp-to-datacatalog-tags/src/main/java/com/example/dlp/DlpDataCatalogTagsTutorial.java
@@ -186,11 +186,7 @@ public class DlpDataCatalogTagsTutorial {
             continue;
           } else if (tableName == null
               || tableName.equalsIgnoreCase("")
-              || currentTable.equalsIgnoreCase(tableName)
-              || (dbType.equalsIgnoreCase("bigquery")
-              && dbName != null
-              && !dbName.equalsIgnoreCase("")
-              && dbName.equalsIgnoreCase(currentDatabaseName))) {
+              || currentTable.equalsIgnoreCase(tableName)) {
 
             countTablesScanned++;
 


### PR DESCRIPTION
Some updates on this tutorial:

1 - Added a fix to the code
There is an issue when using together the filters `tableName` and `dbName`, the `dbName` overrides the other filter.

The `dbName` filter logic is duplicated and causing this issue. This fix solves the problem, and allows filtering just with `dbName`, just with `tableName` or with both.

fixes #1374 