### PR TITLE
Update how-to-roll-your-app-engine-managed-vms-app-back-to-a-previous…

### DIFF
--- a/tutorials/how-to-roll-your-app-engine-managed-vms-app-back-to-a-previous-version-part-1.md
+++ b/tutorials/how-to-roll-your-app-engine-managed-vms-app-back-to-a-previous-version-part-1.md
@@ -52,7 +52,7 @@ Create a file named `server.js` with the following contents:
 
 Let's test it to make sure it works:
 
-    node app.js
+    node server.js
 
 Point your browser to [http://localhost:8080](http://localhost:8080) to see a
 `Hello World!` message. Press CTRL+C to stop the app.
@@ -100,9 +100,15 @@ traffic. You can view any other deployed version at the following url:
 
 Since we've only deployed once you probably only see one version. Let's deploy
 again to see another version, but before we deploy let's introduce a bug into
-our app. Edit the first line of `server.js` to say the following:
+our app. Edit the these lines of `server.js` 
 
-    const httpTypo = require('http');
+     res.writeHead(200, { 'Content-Type': 'text/plain' });
+     res.end('Hello World!\n');
+
+to say the following:
+
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end('Error page\n');
 
 This will cause the app to fail to start. Now deploy:
 

--- a/tutorials/how-to-roll-your-app-engine-managed-vms-app-back-to-a-previous-version-part-1.md
+++ b/tutorials/how-to-roll-your-app-engine-managed-vms-app-back-to-a-previous-version-part-1.md
@@ -10,7 +10,7 @@ date_published: 2015-12-18
 
 You've deployed an app using App Engine flexible environment, and things
 are going great. You make some change to your app and re-deploy, only to
-discover that something broke! You forgot a semicolon and now your users are
+discover that something broke. You forgot a semicolon and now your users are
 upset. What do you do?
 
 One option would be to quickly add the semicolon, commit the fix, and deploy
@@ -18,23 +18,23 @@ again. Hopefully, your app only suffered a few minutes of downtime, depending on
 when you noticed the missing semicolon.
 
 But what if it wasn't just a missing semicolon? What if you just deployed a
-major feature and you don't yet know what the problem is? In this scenario it
+major feature and you don't yet know what the problem is? In this scenario, it
 might be better to quickly rollback to the stable version of your app that was
 running before things broke.
 
-So how do we do that with App Engine flexible environment? A naive approach
+So how do you do that with App Engine flexible environment? A naive approach
 might be to search your source control for the last point in time where your
 code was stable and re-deploy that code. The pressure of downtime turns such a
-search into a nightmare—you could be losing users and dollars by the second!
+search into a nightmare—you could be losing users and dollars by the second.
 There must be a better way.
 
 Enter _versions_, a feature of App Engine flexible environment. Every time you
 deploy an app, the deployment is associated with a version. If you don't specify
-a version then one will be generated for you. Let's try it.
+a version, then one will be generated for you.
 
 ## Sample app
 
-For this tutorial we'll make a tiny Hello World Node.js app and deploy it.
+For this tutorial, you'll make a tiny Hello World Node.js app and deploy it.
 
 Create a file named `server.js` with the following contents:
 
@@ -45,17 +45,17 @@ Create a file named `server.js` with the following contents:
 
     http.createServer((req, res) => {
       res.writeHead(200, { 'Content-Type': 'text/plain' });
-      res.end('Hello World!\n');
+      res.end('Hello, World!\n');
     }).listen(port, hostname, () => {
       console.log(`Server running at http://${hostname}:${port}/`);
     });
 
-Let's test it to make sure it works:
+Test it to make sure that it works:
 
     node server.js
 
 Point your browser to [http://localhost:8080](http://localhost:8080) to see a
-`Hello World!` message. Press CTRL+C to stop the app.
+`Hello, World!` message. Press CTRL+C to stop the app.
 
 ## Deploy
 
@@ -64,27 +64,27 @@ Create a file named `app.yaml` with the following contents:
     runtime: nodejs
     env: flex
 
-This configuration file tells App Engine how to run our app.
+This configuration file tells App Engine how to run your app.
 
-Now create a file named `package.json` with the following contents:
+Create a file named `package.json` with the following contents:
 
     {
         "name": "sample-app"
     }
 
-Assuming you've created a project in the Google Cloud Platform Developers
-Console and installed the Cloud SDK locally, you should be ready to deploy.
+Assuming that you've created a project in the Cloud Console
+and installed the Cloud SDK locally, you should be ready to deploy the app.
 
-Run the following command to deploy:
+Run the following command to deploy the app:
 
     gcloud app deploy
 
 The new deployment should start receiving all traffic, and any previously
 deployed version should stop receiving traffic.
 
-Now view the deployed app at `http://[YOUR_PROJECT_ID].appspot.com/`.
+View the deployed app at `http://[YOUR_PROJECT_ID].appspot.com/`.
 
-We didn't specify a version with the `--version` flag, so one was generated
+You didn't specify a version with the `--version` flag, so one was generated
 automatically. The generated version might look something like `20151005t21174`.
 To see the generated version go to this address:
 
@@ -92,40 +92,43 @@ To see the generated version go to this address:
 
 There you'll see a list of all deployed versions of your app. The version with
 the `(default)` tag next to it is the version that is currently receiving
-traffic. You can view any other deployed version at the following url:
+traffic. You can view any other deployed version at the following URL:
 
 `http://VERSION-dot-[YOUR_PROJECT_ID].appspot.com/`
 
 ## Broken deployment
 
-Since we've only deployed once you probably only see one version. Let's deploy
-again to see another version, but before we deploy let's introduce a bug into
-our app. Edit the these lines of `server.js` 
+Since you've only deployed once, you probably only see one version. In this section,
+you deploy the app again after introducing a bug into the app. 
+
+Find these lines of the `server.js` file:
 
      res.writeHead(200, { 'Content-Type': 'text/plain' });
      res.end('Hello World!\n');
 
-to say the following:
+Edit those two lines to be the following:
 
     res.writeHead(500, { 'Content-Type': 'text/plain' });
     res.end('Error page\n');
 
-This will cause the app to fail to start. Now deploy:
+This will cause the app to fail to start. 
+
+Deploy the app:
 
     gcloud app deploy
 
 You should now see two versions listed, the most recent one of which has the
 `(default)` tag. Even though the new version is receiving all traffic, the first
-version we deployed is still running and consuming resources. If you visit
+version that you deployed is still running and consuming resources. If you visit
 `http://[YOUR_PROJECT_ID].appspot.com/` you should see something that suggests
-that the app isn't working. Time to rollback!
+that the app isn't working. Time to roll back.
 
 ## Rollback
 
-We don't want to mess around with our code, we need to fix this right now. Users
-are upset! Go back to the list of versions and check the box next to the version
-that was deployed first. Now click the `MAKE DEFAULT` button located above the
-list. Traffic immediately switches over to the stable version. Crisis averted!
+You don't want to mess around with your code; you need to fix this right now. Users
+are upset. Go back to the list of versions and check the box next to the version
+that was deployed first. Click the `MAKE DEFAULT` button located above the
+list. Traffic immediately switches over to the stable version. Crisis averted.
 
 That was easy.
 
@@ -134,13 +137,11 @@ and then clicking the `DELETE` button located above the list.
 
 ## Summary
 
-Let's summarize:
-
 - If you don't specify a version when you a deploy then a version will be
 generated for you.
 - The `--promote` flag causes a newly deployed version to start receiving all
 traffic, and is set by default.
-- The `--no-promote` flag causes a newly deployed version to NOT start receiving
+- The `--no-promote` flag causes a newly deployed version to _not_ start receiving
 all traffic. Whatever is currently receiving traffic will continue to receive
 traffic.
 - At any given time, the version with the `(default)` tag is the version


### PR DESCRIPTION
…-version-part-1.md

This has been tested as on 28 Aug 2020.  httpTypo in the code results in an error that is caught in the local testing itself, so hopefully the proposed example will simulate the disaster scenario.