### PR TITLE
Allow service account to launch Dataflow job

### DIFF
--- a/tutorials/schedule-dataflow-jobs-with-cloud-scheduler/scheduler-dataflow-demo/terraform/main.tf
+++ b/tutorials/schedule-dataflow-jobs-with-cloud-scheduler/scheduler-dataflow-demo/terraform/main.tf
@@ -32,7 +32,8 @@ resource "google_cloud_scheduler_job" "scheduler" {
       "environment": {
         "maxWorkers": "10",
         "tempLocation": "gs://${var.bucket}/temp",
-        "zone": "${var.region}-a"
+        "zone": "${var.region}-a",
+        "serviceAccountEmail": "${google_service_account.cloud-scheduler-demo.email}"
       }
     }
 EOT
@@ -45,15 +46,15 @@ resource "google_service_account" "cloud-scheduler-demo" {
   display_name = "A service account for running dataflow from cloud scheduler"
 }
 
-resource "google_project_iam_member" "cloud-scheduler-dataflow" {
+resource "google_project_iam_member" "cloud-scheduler-dataflow-admin" {
   project = var.project_id
   role = "roles/dataflow.admin"
   member = "serviceAccount:${google_service_account.cloud-scheduler-demo.email}"
 }
 
-resource "google_project_iam_member" "cloud-scheduler-gcs" {
+resource "google_project_iam_member" "cloud-scheduler-dataflow-worker" {
   project = var.project_id
-  role = "roles/compute.storageAdmin"
+  role = "roles/dataflow.worker"
   member = "serviceAccount:${google_service_account.cloud-scheduler-demo.email}"
 }
 


### PR DESCRIPTION
1) Grant cloud-scheduler-demo service account "Dataflow Worker" IAM role, which is needed to manage GCE resources used by Dataflow.  Alternatives are either to:

a) Grant "Service Account User" role for cloud-scheduler-demo to the default GCE service account, or 
b) Create a separate service account altogether with the "Dataflow Worker" IAM role, and specify this in (2).

2) Include "serviceAccountEmail" in the Dataflow template paramters.  You can omit this if you've granted "Service Account User" to cloud-scheduler-demo for the default GCE service account.