### PR TITLE
Update location of sample code for python-vision-quickstart

### DIFF
--- a/tutorials/python-vision-quickstart.md
+++ b/tutorials/python-vision-quickstart.md
@@ -76,13 +76,13 @@ rm -rf python-docs-samples
 Clone the sample repository:
 
 ```bash
-git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
+git clone https://github.com/googleapis/python-vision.git
 ```
 
 Change directory to the tutorial directory:
 
 ```bash
-cd python-docs-samples/vision/cloud-client/quickstart
+cd python-vision/samples/snippets/quickstart
 ```
 
 You are now in the main directory for the sample code.


### PR DESCRIPTION
This PR updates the base location of the quickstart referenced in this tutorial. 

Location of example changed in https://github.com/GoogleCloudPlatform/python-docs-samples/pull/4765

This tutorial is also accessed via https://cloud.google.com/vision/docs/label-detection-tutorial