### PR TITLE
Edit - Community Tutorial: inspect BigQuery with DLP and integrate with Data Catalog

### DIFF
--- a/tutorials/dlp-to-datacatalog-tags/src/main/java/com/example/dlp/DlpDataCatalogTagsTutorial.java
+++ b/tutorials/dlp-to-datacatalog-tags/src/main/java/com/example/dlp/DlpDataCatalogTagsTutorial.java
@@ -281,7 +281,9 @@ public class DlpDataCatalogTagsTutorial {
           ds2.setURL(currentUrl);
           connInside = ds2.getConnection();
           sqlQuery =
-              "SELECT * from " + currentDatabaseName + "." + currentTable + " limit " + limitMax;
+              // ADD ` to escape reserved keywords.
+              "SELECT * from " + "`" + currentDatabaseName + "`" + "." + "`" + currentTable +
+                  "`" + " limit " + limitMax;
         }
 
         Statement stmt = connInside.createStatement();


### PR DESCRIPTION
Some updates on this tutorial:

1 - Escape dataset and table names to work with reserved  keyword.

An user reported the following error:   

```For some reason if you pass the parameter dbname (bigquery dataset) as Default (like I have it in my project) -dbName Default you will get an error: "java.sql.SQLException: [Simba][BigQueryJDBCDriver](100032) Error executing query job. Message: Syntax error: Unexpected keyword DEFAULT at [1:15]", after I created another dataset (DLP) and changed the parameter respectively -dbName DLP it run ok```

This PR fixes it, by escaping the dataset and table names.