### PR TITLE
added notes to the automl model export tutorial, particularly re: cloud run image issue

### DIFF
--- a/tutorials/automl-tables-model-export/index.md
+++ b/tutorials/automl-tables-model-export/index.md
@@ -23,7 +23,9 @@ model in [TensorBoard](https://www.tensorflow.org/tensorboard).
 This tutorial uses the [Cloud Console](https://console.cloud.google.com/automl-tables/datasets), but you could also accomplish the same steps through the 
 command-line interface or using the [AutoML Tables client libraries](https://googleapis.dev/python/automl/latest/gapic/v1beta1/tables.html).
 
-> **Note**: this tutorial applies to the AutoML Tables service as accessed here: https://console.cloud.google.com/automl-tables/.  Export of the ([Preview) AutoML Tabular models](https://console.cloud.google.com/ai/platform/models) requires a slightly different process.  This tutorial will be updated soon to include both.
+> **Note**: This tutorial applies to the AutoML Tables service as accessed here: https://console.cloud.google.com/automl-tables/. Export of the
+([Preview) AutoML Tabular models](https://console.cloud.google.com/ai/platform/models) requires a slightly different process. We intend to update this tutorial
+soon to include both.
 
 ## About the dataset and scenario
 
@@ -196,7 +198,8 @@ Viewing your exported model in TensorBoard requires a conversion step. You need 
 
 ## Create a Cloud Run service based on your exported model
 
-> **Note: currently, this part of the tutorial does not work properly due to a change in the `model_server` base image, though you can still use your created container image locally.  The tutorial will be updated soon with a fix.**
+> **Note**: Currently, this part of the tutorial doesn't work properly because of a change in the `model_server` base image, though you can still use your
+created container image locally. We intend to update this tutorial soon with a fix.
 
 At this point, you have a trained model that you've exported and tested locally. You are almost ready to deploy it to
 [Cloud Run](https://cloud.google.com/run/docs/). As the last step of preparation, you create a container image that uses 

--- a/tutorials/automl-tables-model-export/index.md
+++ b/tutorials/automl-tables-model-export/index.md
@@ -23,6 +23,8 @@ model in [TensorBoard](https://www.tensorflow.org/tensorboard).
 This tutorial uses the [Cloud Console](https://console.cloud.google.com/automl-tables/datasets), but you could also accomplish the same steps through the 
 command-line interface or using the [AutoML Tables client libraries](https://googleapis.dev/python/automl/latest/gapic/v1beta1/tables.html).
 
+> **Note**: this tutorial applies to the AutoML Tables service as accessed here: https://console.cloud.google.com/automl-tables/.  Export of the ([Preview) AutoML Tabular models](https://console.cloud.google.com/ai/platform/models) requires a slightly different process.  This tutorial will be updated soon to include both.
+
 ## About the dataset and scenario
 
 The [Cloud Public Datasets Program](https://cloud.google.com/bigquery/public-data/) makes available public datasets that are useful for experimenting with 
@@ -193,6 +195,8 @@ Viewing your exported model in TensorBoard requires a conversion step. You need 
     ![Zooming in to see part of the model graph in more detail](https://storage.googleapis.com/gcp-community/tutorials/automl-tables-model-export/tb3.png)
 
 ## Create a Cloud Run service based on your exported model
+
+> **Note: currently, this part of the tutorial does not work properly due to a change in the `model_server` base image, though you can still use your created container image locally.  The tutorial will be updated soon with a fix.**
 
 At this point, you have a trained model that you've exported and tested locally. You are almost ready to deploy it to
 [Cloud Run](https://cloud.google.com/run/docs/). As the last step of preparation, you create a container image that uses 


### PR DESCRIPTION
Adds a note re: the Cloud Run issue (which needs more time to be debugged), plus a clarification that the tutorial applies to  'CAIP AutoML', not 'uCAIP Tabular'.  The process is a little different for that and I'll update the tutorial to include both in a later PR.