### PR TITLE
get_object -> get_obj per documentation

### DIFF
--- a/tutorials/using-flask-login-with-cloud-datastore/index.md
+++ b/tutorials/using-flask-login-with-cloud-datastore/index.md
@@ -135,7 +135,7 @@ def login():
 
         # fetch user using the 'username' property
         # refer to the datastore-entity documentation for more
-        user = User().get_object('username',identity)
+        user = User().get_obj('username',identity)
 
         if user and user.authenticated(password):
 


### PR DESCRIPTION
Docs now show this method as `get_obj` not `get_object`: https://datastore-entity.readthedocs.io/en/latest/#retrieving-entity-as-object