### PR TITLE
fixed bug where clamscan is used instead of clamdscan

### DIFF
--- a/tutorials/gcp-cos-clamav/scan.sh
+++ b/tutorials/gcp-cos-clamav/scan.sh
@@ -8,7 +8,7 @@ if [ -f "$LOCK" ];then
 else
   touch $LOCK
   echo `date` Starting scan |tee -a /logs/clamscan.log
-  clamscan \
+  clamdscan \
     --verbose \
     --stdout \
     --log=/logs/clamscan.log \


### PR DESCRIPTION
The container entrypoint is `start.py.`

This script creates a cronjob to  run `clamscan` every hour. 

`start.py `ends by executing `clamd`, which starts the clamd daemon. The daemon does nothing by itself, except load the virus database and wait for instructions. 


`clamdscan` sends instructions to the daemon to scan files. 
`clamscan` loads the virus database independently, and then sends instructions to scan files. It does not interact with the clamd daemon. 

https://www.clamav.net/documents/scanning
> Unlike clamdscan, clamscan does not require a running clamd instance to function. Instead, clamscan will create a new engine and load in the virus database each time it is run. It will then scan the files and/or directories specified at the command line, create a scan report, and exit.


It is redundant to start the engine with clamd and then use clamscan instead of clamdscan - this change will half the memory footprint of the container. 