### PR TITLE
Convert clamav scanner from clamscan to clamdscan

### DIFF
--- a/tutorials/gcp-cos-clamav/Dockerfile
+++ b/tutorials/gcp-cos-clamav/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /logs /data
 RUN echo `date`: File created >> /logs/clamscan.log
 RUN chmod +r /etc/fcron/*
 
-COPY conf /etc/clamav
+COPY conf /etc/clamav-custom
 COPY start.py /start.py
 COPY health.sh /health.sh
 COPY scan.sh /scan.sh

--- a/tutorials/gcp-cos-clamav/build
+++ b/tutorials/gcp-cos-clamav/build
@@ -1,5 +1,5 @@
 # This script automates the build and publication of the docker image
-DOCKER_REPO=ianmaddox
+DOCKER_REPO=YOUR_REPO_HERE
 HOSTNAME=docker.io
 docker build -t clamav .
 docker tag clamav $HOSTNAME/$DOCKER_REPO/clamav:latest

--- a/tutorials/gcp-cos-clamav/conf/clamd.conf
+++ b/tutorials/gcp-cos-clamav/conf/clamd.conf
@@ -5,14 +5,17 @@
 DatabaseDirectory /data
 TemporaryDirectory /tmp
 LogTime yes
-#LogSyslog yes
 LogFile /logs/clamav.log
-LogVerbose yes
+LogVerbose no
 LogClean yes
 PidFile /run/clamd.pid
 LocalSocket /tmp/clamd.sock
 TCPSocket 3310
 Foreground yes
+MaxThreads 4
+ExcludePath /host-fs/dev
+ExcludePath /host-fs/sys
+ExcludePath /host-fs/var/lib/docker
 
 ###############
 # Results
@@ -48,6 +51,7 @@ ScanArchive yes
 MaxScanSize 150M
 MaxFileSize 30M
 MaxRecursion 10
+MaxDirectoryRecursion 100
 MaxFiles 15000
 MaxEmbeddedPE 10M
 MaxHTMLNormalize 10M

--- a/tutorials/gcp-cos-clamav/index.md
+++ b/tutorials/gcp-cos-clamav/index.md
@@ -24,3 +24,21 @@ ClamAV is an open source antivirus engine for detecting trojans, viruses, malwar
 1. Ensure scan-required paths within other pods are mounted as named volumes so they will be included in the scan of the node.
 
 For more information, see [Installing antivirus and file integrity monitoring on Container-Optimized OS](https://cloud.google.com/solutions/installing-antivirus-and-file-integrity-monitoring-on-container-optimized-os).
+
+Use the following to create the container:
+```
+IMAGE=clamav
+CONTAINER=clamav
+APP=clamav
+BASEDIR=/[[DOCKER_APP_CONFIG_PATH]]/$APP
+
+docker create --name=$APP \
+   -v /share:/host-fs:ro \
+   -v $BASEDIR/logs:/logs \
+   -v $BASEDIR/conf:/etc/clamav \
+   --health-cmd "/health.sh" \
+   $IMAGE
+```
+Be sure to define DOCKER_APP_CONFIG_PATH.
+The first time you launch the container, default config files will be deployed into the conf/ subfolder. You can customize the config files and they will be deployed next launch.
+Be sure to tune the `clamd.conf` MaxThreads value to work well with the other workloads.

--- a/tutorials/gcp-cos-clamav/index.md
+++ b/tutorials/gcp-cos-clamav/index.md
@@ -12,7 +12,7 @@ Ian Maddox | Solutions Architect | Google
 
 [This example](https://github.com/GoogleCloudPlatform/community/tree/master/tutorials/gcp-cos-clamav) provides a Clam antivirus Docker image that performs regularly scheduled scans.
 
-This example is designed to be run on Google Container-Optimized OS, but it should work with most other Docker servers.
+This example is designed to be run on Container-Optimized OS, but it should work with most other Docker servers.
 
 ClamAV is an open source antivirus engine for detecting trojans, viruses, malware, and other malicious threats.
 
@@ -21,24 +21,26 @@ ClamAV is an open source antivirus engine for detecting trojans, viruses, malwar
 1. Build your Docker image.
 1. Deploy that image to your Kubernetes cluster.
 1. Use Daemonsets to configure the new workload to run one scanner pod per node.
-1. Ensure scan-required paths within other pods are mounted as named volumes so they will be included in the scan of the node.
+1. Ensure that scan-required paths within other pods are mounted as named volumes so they will be included in the scan of the node.
 
-For more information, see [Installing antivirus and file integrity monitoring on Container-Optimized OS](https://cloud.google.com/solutions/installing-antivirus-and-file-integrity-monitoring-on-container-optimized-os).
+For more information, see
+[Installing antivirus and file integrity monitoring on Container-Optimized OS](https://cloud.google.com/solutions/installing-antivirus-and-file-integrity-monitoring-on-container-optimized-os).
 
-Use the following to create the container:
-```
-IMAGE=clamav
-CONTAINER=clamav
-APP=clamav
-BASEDIR=/[[DOCKER_APP_CONFIG_PATH]]/$APP
+Use the following to create the container, replacing `[DOCKER_APP_CONFIG_PATH]` with the value for you environment:
 
-docker create --name=$APP \
-   -v /share:/host-fs:ro \
-   -v $BASEDIR/logs:/logs \
-   -v $BASEDIR/conf:/etc/clamav \
-   --health-cmd "/health.sh" \
-   $IMAGE
-```
-Be sure to define DOCKER_APP_CONFIG_PATH.
-The first time you launch the container, default config files will be deployed into the conf/ subfolder. You can customize the config files and they will be deployed next launch.
-Be sure to tune the `clamd.conf` MaxThreads value to work well with the other workloads.
+    IMAGE=clamav
+    CONTAINER=clamav
+    APP=clamav
+    BASEDIR=/[DOCKER_APP_CONFIG_PATH]/$APP
+
+    docker create --name=$APP \
+       -v /share:/host-fs:ro \
+       -v $BASEDIR/logs:/logs \
+       -v $BASEDIR/conf:/etc/clamav \
+       --health-cmd "/health.sh" \
+       $IMAGE
+
+The first time you start the container, default configuration files will be deployed into the `conf/` subfolder. You can customize the configuration
+files, and they will be deployed the next time you start the container.
+
+Be sure to tune the `MaxThreads` value in `clamd.conf` to work well with the other workloads.

--- a/tutorials/gcp-cos-clamav/scan.sh
+++ b/tutorials/gcp-cos-clamav/scan.sh
@@ -7,15 +7,7 @@ if [ -f "$LOCK" ];then
   exit
 else
   touch $LOCK
-  echo `date` Starting scan |tee -a /logs/clamscan.log
-  clamscan \
-    --verbose \
-    --stdout \
-    --log=/logs/clamscan.log \
-    --recursive \
-    --exclude=/host-fs/dev \
-    --exclude=/host-fs/sys \
-    --exclude=/host-fs/var/lib/docker \
-    /host-fs
+  echo `date` Starting scan
+  clamdscan --multiscan /host-fs
   rm $LOCK
 fi

--- a/tutorials/gcp-cos-clamav/start.py
+++ b/tutorials/gcp-cos-clamav/start.py
@@ -1,6 +1,17 @@
 #!/usr/bin/python3
 
 import os
+from os import path
+
+# Init the configs so they can be maintained from outside the container
+def init_conf(conffile):
+    os.system(f"cp /etc/clamav-custom/{conffile} /etc/clamav/{conffile}")
+
+init_conf("clamd.conf")
+init_conf("freshclam.conf")
+if os.path.exists("/tmp/clamscan.lock"):
+    print("Cleaning up lock file from bad shutdown")
+    os.remove("/tmp/clamscan.lock")
 
 # Schedule a filesystem scan every hour unless one is in progress.
 os.system("echo \"$(($RANDOM % 60))   *   *   *   *   /scan.sh > /proc/1/fd/1 2>&1\" > /root.crontab")

--- a/tutorials/gcp-cos-clamav/start.py
+++ b/tutorials/gcp-cos-clamav/start.py
@@ -5,7 +5,9 @@ from os import path
 
 # Init the configs so they can be maintained from outside the container
 def init_conf(conffile):
-    os.system(f"cp /etc/clamav-custom/{conffile} /etc/clamav/{conffile}")
+    if not os.path.exists(f"/etc/clamav/{conffile}"):
+        print(f"Initializing conf file {conffile}")
+        os.system(f"cp /etc/clamav-custom/{conffile} /etc/clamav/{conffile}")
 
 init_conf("clamd.conf")
 init_conf("freshclam.conf")


### PR DESCRIPTION
Inspired by PR #1597, this switches the scanning application from clamscan to clamdscan. The daemon clamd was already running, so now we're using it.
Moved the clamscan command line args into the clamd config file.
Updated readme
Added the ability for custom configs that live outside the container
Added the ability to gracefully recover from an incomplete scan