### PR TITLE
Instructions to use gradlew for consistent build

### DIFF
--- a/tutorials/auto-bigquery-tokenize/index.md
+++ b/tutorials/auto-bigquery-tokenize/index.md
@@ -233,7 +233,7 @@ You can use your own file datasets or copy the included demonstration dataset (`
 
 You need to compile all of the modules to build executables for deploying the sample-and-identify and tokenize pipelines.
 
-     gradle buildNeeded shadowJar
+     ./gradlew buildNeeded shadowJar
 
 **Tip**: To skip running the tests, you can add the `-x test` flag.
 

--- a/tutorials/auto-data-tokenize/index.md
+++ b/tutorials/auto-data-tokenize/index.md
@@ -296,7 +296,7 @@ You can use your own file datasets or copy the included demonstration dataset (`
 
 You need to compile all of the modules to build executables for deploying the sample-and-identify and tokenize pipelines.
 
-     gradle buildNeeded shadowJar
+     ./gradlew buildNeeded shadowJar
 
 **Tip**: To skip running the tests, you can add the `-x test` flag.
 


### PR DESCRIPTION
using plain `gradle` results in inconsistent builds due to dependence on local gradle version. update instructions to use `gradlew` for using [gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) for consistent builds.