### PR TITLE
Fix a typo in the secret manager python tutorial

### DIFF
--- a/tutorials/secrets-manager-python/index.md
+++ b/tutorials/secrets-manager-python/index.md
@@ -27,7 +27,7 @@ directory on GitHub.
 
 1.  This tutorial requires a Google Cloud project.
     [Create a new Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
-    or open an exisitng project in the [Cloud Console](https://console.cloud.google.com/cloud-resource-manager).
+    or open an existing project in the [Cloud Console](https://console.cloud.google.com/cloud-resource-manager).
 
 1.  You use the Cloud Shell command-line interface in the Cloud Console to run commands in this tutorial. Open Cloud Shell
     by clicking the **Activate Cloud Shell** button in the navigation bar in the upper-right corner of the Cloud Console.


### PR DESCRIPTION
Hello! I was browsing the Secret Manager Python tutorial and spotted a typo. Figured I'd submit a small fix. 