### PR TITLE
Update documentation to support Homebrew 3.*

### DIFF
--- a/tutorials/developing-services-with-k8s.md
+++ b/tutorials/developing-services-with-k8s.md
@@ -45,10 +45,10 @@ First, install the `gcloud` and `kubectl` command line tools. Follow the instruc
 You need to install Telepresence, which will proxy your locally running service to Google Kubernetes Engine. (For the latest 
 installation instructions and documentation, visit [the Telepresence website](http://www.telepresence.io).)
 
-On OS X:
+On macOS (Homebrew 3 or later):
 
 ```
-brew cask install osxfuse
+brew install --cask osxfuse
 brew install datawire/blackbird/telepresence
 ```
 


### PR DESCRIPTION
The provided macOS commands do not work with the most recent version of Homebrew 3.*.
Due to this, I provided the correct instructions for the most recent version of Homebrew as well as clarified which version of the command is used.