### PR TITLE
PR with tutorials/cicd-cloud-run-github-actions/index.md

### DIFF
--- a/tutorials/cicd-cloud-run-github-actions/index.md
+++ b/tutorials/cicd-cloud-run-github-actions/index.md
@@ -259,7 +259,7 @@ Create a `GCP-Deploy.yml` file and copy this content into it:
             - name: Login
               uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
               with:
-                GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+                project_id: ${{ secrets.GCP_PROJECT_ID }}
                 service_account_email: ${{ secrets.GCP_EMAIL }}
                 service_account_key: ${{ secrets.GCP_CREDENTIALS }}
 


### PR DESCRIPTION
Hi,

Thank you for great tutorial, and it has really helped me. However, since I found one mistake in it, I fixed it.

As for `Login` step in `GCP-Deploy.yml`, you provide `GCP_PROJECT_ID` as the input. This setting did not work for me, and warnings like below were appeared.

```bash
Unexpected input(s) 'GCP_PROJECT_ID', valid inputs are ['version', 'service_account_email', 'service_account_key', 'project_id', 'export_default_credentials', 'credentials_file_path']
```

After I changed `GCP_PROJECT_ID` into `project_id` in accordance with the warnings, it worked for me. Thank you for your check in advance.