### PR TITLE
Updated published date-stamp...

### DIFF
--- a/tutorials/getting-started-on-gcp-with-terraform/index.md
+++ b/tutorials/getting-started-on-gcp-with-terraform/index.md
@@ -3,7 +3,7 @@ title: Getting started with Terraform on Google Cloud
 description: Learn how to get a simple web server running on Compute Engine using Terraform to do the provisioning of resources.
 author: chrisst
 tags: terraform
-date_published: 2018-08-17
+date_published: 2020-10-05
 ---
 
 Chris Stephens | Software Engineer | Google


### PR DESCRIPTION
...considering that the most recent non-trivial change was in [Oct 2020](https://github.com/GoogleCloudPlatform/community/pull/1461).

It'd be good to show the date when the tutorial was most recently updated, in place of the date of the first publication.