### PR TITLE
Add repository cloning step in dlp-hybrid-inspect

### DIFF
--- a/tutorials/dlp-hybrid-inspect/index.md
+++ b/tutorials/dlp-hybrid-inspect/index.md
@@ -102,15 +102,17 @@ Reminder: If you want to see detailed findings or run analysis on findings, we r
 
 ## Build
 
-Clone the source repository for this tutorial:
+1.  Clone the source repository for this tutorial:
 
-    git clone https://github.com/GoogleCloudPlatform/community.git
-    cd community/tutorials/dlp-hybrid-inspect
+        git clone https://github.com/GoogleCloudPlatform/community.git
+        
+1.  Go to the directory for this tutorial:
 
+        cd community/tutorials/dlp-hybrid-inspect
 
-Run the following command to compile the script:
+1.  Compile the script:
 
-    mvn clean package -DskipTests
+        mvn clean package -DskipTests
 
 ## Command-line parameters
 

--- a/tutorials/dlp-hybrid-inspect/index.md
+++ b/tutorials/dlp-hybrid-inspect/index.md
@@ -102,6 +102,12 @@ Reminder: If you want to see detailed findings or run analysis on findings, we r
 
 ## Build
 
+Clone the source repository for this tutorial:
+
+    git clone https://github.com/GoogleCloudPlatform/community.git
+    cd community/tutorials/dlp-hybrid-inspect
+
+
 Run the following command to compile the script:
 
     mvn clean package -DskipTests


### PR DESCRIPTION
Fix: Add missing step to clone the repository to compile and run the code in the tutorial