### PR TITLE
update fluentbit version from 1.6 to 1.8

### DIFF
--- a/tutorials/kubernetes-engine-customize-fluentbit/kubernetes/fluentbit-daemonset.yaml
+++ b/tutorials/kubernetes-engine-customize-fluentbit/kubernetes/fluentbit-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: fluent-bit
-        image: gcr.io/cloud-solutions-images/fluent-bit:1.6
+        image: gcr.io/cloud-solutions-images/fluent-bit:1.8
         imagePullPolicy: Always
         ports:
           - containerPort: 2020


### PR DESCRIPTION
the stackdriver plugin has bugs that cause the tutorial to fail that
have been fixed in 1.8. Particularly:
https://github.com/fluent/fluent-bit/pull/3330/files