### PR TITLE
removed request property from healthcheck

### DIFF
--- a/tutorials/sql-server-ao-single-subnet/index.md
+++ b/tutorials/sql-server-ao-single-subnet/index.md
@@ -355,7 +355,6 @@ receives the signal, and traffic is redirected to the other node.
             --healthy-threshold=1 \
             --unhealthy-threshold=2 \
             --port=59997 \
-            --request=10.128.0.20 \
             --timeout="1s"
 
 1.  Add a firewall rule to allow the health check:


### PR DESCRIPTION
The following property : "request" is not needed. If this property it populated then the response property also needs to be populated. 

If the request and response don't match then amber lights appear on the load balancer UI (rather than one green and one amber - desired). Listener resolution is also impacted, resulting in timeouts and longer time to failover / failback.

Let's keep both the request and response properties of the healthcheck blank to avoid load balancer  / hc issues. 

ref: https://cloud.google.com/load-balancing/docs/health-check-concepts?&_ga=2.139983091.-1312798538.1627908672#criteria-protocol-ssl-tcp

Change:  removed the following: 
            --request=10.128.0.20 \