### PR TITLE
Tutorial clarification

### DIFF
--- a/tutorials/nginx-ingress-gke/index.md
+++ b/tutorials/nginx-ingress-gke/index.md
@@ -245,7 +245,10 @@ status field in confusing ways. For more information, see
     The `kind: Ingress` line dictates that this is an Ingress Resource object. This Ingress Resource defines an inbound L7 rule for path `/hello` to service
     `hello-app` on port 8080.
 
-    The `host` specification of the `Ingress` resource should match the FQDN of the Service. The NGINX Ingress Controller requires the use of a Fully Qualified Domain Name (FQDN) in that line, so you can't use the contents of the $NGINX_INGRESS_IP here directly. Services such as nip.io will return an IP address for a hostname with an embedded IP address (i.e. querying `[IP_ADDRESS].nip.io` returns `[IP_ADDRESS]`), so you can use that here instead. In production, you can replace the `host` specification in the `Ingress` resource with your real FQDN for the Service.
+    The `host` specification of the `Ingress` resource should match the FQDN of the Service. The NGINX Ingress Controller requires the use of a Fully Qualified
+    Domain Name (FQDN) in that line, so you can't use the contents of the `$NGINX_INGRESS_IP` variable directly. Services such as nip.io return an IP address for
+    a hostname with an embedded IP address (i.e., querying `[IP_ADDRESS].nip.io` returns `[IP_ADDRESS]`), so you can use that instead. In production, you can 
+    replace the `host` specification in the `Ingress` resource with your real FQDN for the Service.
 
 1.  Apply the configuration:
 
@@ -255,14 +258,15 @@ status field in confusing ways. For more information, see
 
         kubectl get ingress ingress-resource
 
-    The IP address for the Ingress Resource will not be defined right away, so you may need to wait a few moments for the `ADDRESS` field to get populated. The IP address should match the contents of the $NGINX_INGRESS_IP variable.
+    The IP address for the Ingress Resource will not be defined right away, so you may need to wait a few moments for the `ADDRESS` field to get populated. The 
+    IP address should match the contents of the `$NGINX_INGRESS_IP` variable.
 
     The output should look like the following:
 
         NAME               CLASS    HOSTS                  ADDRESS   PORTS   AGE
         ingress-resource   <none>   34.122.88.204.nip.io             80      10s
 
-    Note that the `HOSTS` value in the output is set to the FQDN specified in the `host` entry of the yaml file.
+    Note that the `HOSTS` value in the output is set to the FQDN specified in the `host` entry of the YAML file.
 
 ### Test Ingress
 


### PR DESCRIPTION
While running though the Nginx Ingress GKE tutorial, I found one IP address in the page that was different from all the others used in the example which was a little confusing, so I made a change to update the one sample IP address.

Also clarified why a `nip.io` FQDN suddenly appeared in the example Ingress resource spec. While the use of the `nip.io` domain is mentioned in the document already, it was further down the page, and not at the location where the domain name is mentioned.