### PR TITLE
Tutorial update: Locally developing microservices with Google Kubernetes Engine

### DIFF
--- a/tutorials/developing-services-with-k8s.md
+++ b/tutorials/developing-services-with-k8s.md
@@ -144,15 +144,15 @@ Go to the external IP address of your load balancer (in the above example, 104.1
 
 What if you want to try out some changes to your code, without having to redeploy it each time?
 
-We're now going to use [Telepresence](http://www.telepresence.io) to create a virtual network between your local machine and the remote Kubernetes cluster. This way, a PHP application running locally will be able to talk to remote cloud resources, and vice versa.
-
-In addition, Telepresence will temporarily replace the pods running the PHP code in Kubernetes with a proxy talking to your local machine:
+We're now going to use [Telepresence](http://www.telepresence.io) to create a virtual network between your local machine and the remote Kubernetes cluster by running this command:
 
 ```
-% telepresence --swap-deployment frontend --expose 8080:80 --run-shell
+% telepresence intercept frontend --port 8080:80
 ```
 
-In this special shell, change to the `examples/guestbook` directory, and start the frontend application as follows. We'll need to know the directory where PHP can load its dependencies, e.g., Predis. You can figure this out by typing:
+This tells Telepresence to send remote traffic to your local service instead of the service in the remote Kubernetes cluster.
+
+Now, change to the `examples/guestbook` directory, and start the frontend application as follows. We'll need to know the directory where PHP can load its dependencies, e.g., Predis. You can figure this out by typing:
 
 ```
 % pear config-get php_dir


### PR DESCRIPTION
The [Locally developing microservices with Google Kubernetes Engine](https://cloud.google.com/community/tutorials/developing-services-with-k8s) tutorial contains commands that were used in Telepresence 1 instead of the current default version (Telepresence 2). This means that any reader who follows the instructions in this tutorial will not achieve its intended goal.

This pull request adds the current commands and modifies its description. Please review!