### PR TITLE
Include a step in dlp hybrid inspect demo to install git/maven

### DIFF
--- a/tutorials/dlp-hybrid-inspect/index.md
+++ b/tutorials/dlp-hybrid-inspect/index.md
@@ -102,7 +102,7 @@ Reminder: If you want to see detailed findings or run analysis on findings, we r
 
 ## Build
 
-1.  Ensure Git and Maven are installed:
+1.  Ensure that Git and Maven are installed:
 
         sudo apt-get install git maven
         

--- a/tutorials/dlp-hybrid-inspect/index.md
+++ b/tutorials/dlp-hybrid-inspect/index.md
@@ -102,6 +102,10 @@ Reminder: If you want to see detailed findings or run analysis on findings, we r
 
 ## Build
 
+1.  Ensure Git and Maven are installed:
+
+        sudo apt-get install git maven
+        
 1.  Clone the source repository for this tutorial:
 
         git clone https://github.com/GoogleCloudPlatform/community.git


### PR DESCRIPTION
On a brand new VM, for example, these won't already be installed, so it's helpful to include this step for those running through the demo.