### PR TITLE
fix: #2018 put google-github-actions on Login step

### DIFF
--- a/tutorials/cicd-cloud-run-github-actions/index.md
+++ b/tutorials/cicd-cloud-run-github-actions/index.md
@@ -257,7 +257,7 @@ Create a `GCP-Deploy.yml` file and copy this content into it:
             steps:
 
             - name: Login
-              uses: google-github-actions/setup-gcloud@master
+              uses: google-github-actions/setup-gcloud@v0
               with:
                 project_id: ${{ secrets.GCP_PROJECT_ID }}
                 service_account_email: ${{ secrets.GCP_EMAIL }}

--- a/tutorials/cicd-cloud-run-github-actions/index.md
+++ b/tutorials/cicd-cloud-run-github-actions/index.md
@@ -257,7 +257,7 @@ Create a `GCP-Deploy.yml` file and copy this content into it:
             steps:
 
             - name: Login
-              uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+              uses: google-github-actions/setup-gcloud@master
               with:
                 project_id: ${{ secrets.GCP_PROJECT_ID }}
                 service_account_email: ${{ secrets.GCP_EMAIL }}


### PR DESCRIPTION
Replace `GoogleCloudPlatform/github-actions/setup-gcloud@master` in the sample YAML by `google-github-actions/setup-gcloud@master` which is the new working repo path for this action

Closes #2018 