### PR TITLE
Update continuous integration : multiple versions of Node Js and Operating System

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 name: ci
 jobs:
   test:
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 name: ci
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 8, 14, 18
+          node-version: 8
       - run: npm install
       - run: npm test
   lint:
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 8, 14, 18
+          node-version: 8
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,20 +8,30 @@ on:
 name: ci
 jobs:
   test:
-    runs-on: [ubuntu-latest, windows-latest, macOS-latest]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 8
-      - run: npm install
-      - run: npm test
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          node: [ 8, 12, 14, 16 ]
+      name: Node ${{ matrix.node }}
+      steps:
+        - uses: actions/checkout@v3
+        - name: Setup node
+          uses: actions/setup-node@v3
+          with:
+            node-version: ${{ matrix.node }}
+        - run: npm install
+        - run: npm test
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 8
-      - run: npm install
-      - run: npm run lint
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          nodelint: [ 8, 12, 14, 16 ]
+      name: Node ${{ matrix.nodelint }}
+      steps:
+        - uses: actions/checkout@v3
+        - name: Setup node
+          uses: actions/setup-node@v3
+          with:
+            node-version: ${{ matrix.node }}
+        - run: npm install
+        - run: npm run lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 8
+          node-version: 8, 14, 18
       - run: npm install
       - run: npm test
   lint:
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 8
+          node-version: 8, 14, 18
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 name: ci
 jobs:
   test:
-    runs-on: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,12 @@ on:
 name: ci
 jobs:
   test:
-      runs-on: ubuntu-latest
+      runs-on: ${{ matrix.os }}
       strategy:
         matrix:
           node: [ 8, 12, 14, 16 ]
-      name: Node ${{ matrix.node }}
+          os: [macos-latest, ubuntu-latest, ubuntu-latest]
+      name: Node ${{ matrix.node }} Run On ${{ matrix.os }}
       steps:
         - uses: actions/checkout@v3
         - name: Setup node
@@ -22,11 +23,12 @@ jobs:
         - run: npm install
         - run: npm test
   lint:
-      runs-on: ubuntu-latest
+      runs-on: ${{ matrix.oslint }}
       strategy:
         matrix:
           nodelint: [ 8, 12, 14, 16 ]
-      name: Node ${{ matrix.nodelint }}
+          oslint: [macos-latest, ubuntu-latest, ubuntu-latest]
+      name: Node ${{ matrix.nodelint }} Run On ${{ matrix.oslint }}
       steps:
         - uses: actions/checkout@v3
         - name: Setup node

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   schedule:
     - cron:  '0 7 * * *'
-name: ci
+name: Continuous Integration
 jobs:
   test:
       runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I changed the default ```ci.yml``` by adding multiple versions of Node Js and Operating System

NodeJS Version:

```
node: [ 8, 12, 14, 16 ]
```

Operating System:
```
os: [macos-latest, ubuntu-latest, ubuntu-latest]
```

Demo : 

https://github.com/rizkytegar/GoogleCloudPlatform/actions/runs/2519581872

https://github.com/rizkytegar/GoogleCloudPlatform/runs/6946504868?check_suite_focus=true

Output in my repository :  

```
All checks have passed
24 successful checks
```

https://github.com/rizkytegar/GoogleCloudPlatform