### PR TITLE
speech2srt: fix broken conversion

### DIFF
--- a/tutorials/speech2srt/speech2srt.py
+++ b/tutorials/speech2srt/speech2srt.py
@@ -63,7 +63,7 @@ def break_sentences(args, subs, alternative):
     for w in alternative.words:
         if firstword:
             # first word in sentence, record start time
-            start = w.start_time.ToTimedelta()
+            start = w.start_time
 
         charcount += len(w.word)
         content += " " + w.word.strip()
@@ -75,7 +75,7 @@ def break_sentences(args, subs, alternative):
             # also break if , and not first word
             subs.append(srt.Subtitle(index=idx,
                                      start=start,
-                                     end=w.end_time.ToTimedelta(),
+                                     end=w.end_time,
                                      content=srt.make_legal_content(content)))
             firstword = True
             idx += 1


### PR DESCRIPTION
start_time and end_time are already datetime.timedeltas

Fixes:
> start = w.start_time.ToTimedelta()
> AttributeError: 'datetime.timedelta' object has no attribute 'ToTimedelta'