### PR TITLE
Update file to remove deprecated link

### DIFF
--- a/tutorials/web-instrumentation/index.md
+++ b/tutorials/web-instrumentation/index.md
@@ -758,6 +758,5 @@ Explore the following related resources:
 * Read about [load balancing in data centers](https://landing.google.com/sre/sre-book/chapters/load-balancing-datacenter/)
   in the SRE Book.
 * Read about [managing load](https://landing.google.com/sre/workbook/chapters/managing-load/) in the SRE Workbook.
-* Adapt the app in this tutorial to a Java backend with [Identifying causes of app latency with Stackdriver and OpenCensus](https://cloud.google.com/solutions/identifying-causes-of-app-latency-with-stackdriver-and-opencensus).
 * Adapt the app in this tutorial to a Go backend with [Troubleshooting app latency with Cloud Spanner and OpenCensus](https://cloud.google.com/solutions/troubleshooting-app-latency-with-cloud-spanner-and-opencensus).
 * Try out other Google Cloud features. Have a look at our [tutorials](https://cloud.google.com/docs/tutorials).


### PR DESCRIPTION
The link https://cloud.google.com/solutions/identifying-causes-of-app-latency-with-stackdriver-and-opencensus is no longer valid. It redirects to https://cloud.google.com/trace/docs/trace-app-latency, or it will in the next few days.