### PR TITLE
apiVersion not supported any more

### DIFF
--- a/tutorials/deploy-dependency-track/deploy/frontend/ingress.yaml
+++ b/tutorials/deploy-dependency-track/deploy/frontend/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: dependency-track-frontend-ing
@@ -7,6 +7,8 @@ metadata:
     kubernetes.io/ingress.allow-http: "false"
     ingress.gcp.kubernetes.io/pre-shared-cert: "dependency-track-cert-ui"
 spec:
-  backend:
-    serviceName: dependency-track-frontend-svc
-    servicePort: 8080
+  defaultBackend:
+    service:
+      name: dependency-track-frontend-svc
+      port: 
+        number: 8080


### PR DESCRIPTION
apiVersion: networking.k8s.io/v1beta1 is not supported anymore. Using apiVersion: networking.k8s.io/v1