### PR TITLE
Fixed speech2srt.py so out.srt will be saved in UTF-8 when language is not english

### DIFF
--- a/tutorials/speech2srt/speech2srt.py
+++ b/tutorials/speech2srt/speech2srt.py
@@ -89,7 +89,7 @@ def break_sentences(args, subs, alternative):
 def write_srt(args, subs):
     srt_file = args.out_file + ".srt"
     print("Writing {} subtitles to: {}".format(args.language_code, srt_file))
-    f = open(srt_file, 'w')
+    f = open(srt_file, 'w', encoding="utf-8")
     f.writelines(srt.compose(subs))
     f.close()
     return
@@ -98,7 +98,7 @@ def write_srt(args, subs):
 def write_txt(args, subs):
     txt_file = args.out_file + ".txt"
     print("Writing text to: {}".format(txt_file))
-    f = open(txt_file, 'w')
+    f = open(txt_file, 'w', encoding="utf-8")
     for s in subs:
         f.write(s.content.strip() + "\n")
     f.close()


### PR DESCRIPTION
speech2srt.py failed with the following error when language code was set to --language_code iw
`UnicodeEncodeError: 'charmap' codec can't encode character '\u6c34' in position 0: character maps to <undefined>`
Because it tried to save a unicode string to file without the proper encoding.
So Ive added utf-8 encoding when writing the srt file and the text file:
`open(txt_file, 'w', encoding="utf-8")`